### PR TITLE
Pool role accounts

### DIFF
--- a/docs/concepts/core-concepts/pool-role-accounts.md
+++ b/docs/concepts/core-concepts/pool-role-accounts.md
@@ -15,12 +15,13 @@ struct PoolRoleAccounts {
 }
 ```
 
-* pauseManager: Can see Pool paused/unpaused. When a pool is paused all state-changing operations will revert, and putting the pool in recovery mode (if not already done) becomes permissionless
-* swapFeeManager: Set static swap fees for a pool
-* poolCreator: Set the [pool creator fee](./pool-creator-fee.md)
+* pauseManager: Can pause or unpause a pool. When a pool is paused, all state-changing operations will revert, and putting the pool in recovery mode (if not already done) becomes permissionless
+* swapFeeManager: Can set static swap fees for a pool
+* poolCreator: Can set the [pool creator fee](./pool-creator-fee.md)
 
 Passing the zero address grants Balancer Governance permission by default.
 
 ::: info Pause Permission
-Balancer Governance is always granted pauseManager permission as well as any user configure address.
+Balancer Governance can always pause/unpause pools, even if there is a pause manager. However, governance cannot set swap fees if there is a swap manager, or pool creator fees if there is a pool creator.
 :::
+,


### PR DESCRIPTION
Typos, plus clarify the role of governance in pausing and fee setting.