### PR TITLE
Boosted Pools

### DIFF
--- a/docs/concepts/explore-available-balancer-pools/boosted-pool.md
+++ b/docs/concepts/explore-available-balancer-pools/boosted-pool.md
@@ -6,14 +6,14 @@ title: Boosted Pool
 
 ## Overview
 
-Boosted Pools are a type of liquidity pool in which a portion or all of the tokens can generate yield. The yield-bearing tokens can constitute anywhere from 25% to 100% of the pool's total tokens. While the operation of Boosted Pools is not restricted to a specific trading algorithm, they often employ [Stable Math](/concepts/explore-available-balancer-pools/stable-pool/stable-math.html). This is due to the effectiveness of Stable Math in handling assets that have a high correlation.
+Boosted Pools are a type of liquidity pool in which some or all of the tokens can generate yield. The yield-bearing tokens can constitute anywhere from 25% to 100% of the pool's total tokens. While the operation of Boosted Pools is not restricted to a specific trading algorithm, they often employ [Stable Math](/concepts/explore-available-balancer-pools/stable-pool/stable-math.html). This is due to the effectiveness of Stable Math in handling assets that are highly correlated.
 
 ### Advantages of Boosted pools
 
-The main advantage for boosted pools in the Balancer ecosystem are:
+The main advantage of boosted pools in the Balancer ecosystem are:
 
 #### 100% yield bearing possibility
-Balancer V3 boosted pools allow for 100% of an LP position to be considered boosted, meaning to be a yield bearing token. Prominent examples are bb-a-USD which is a StablePool containing Aave yield bearing DAI (`aDAI`), Aave yield bearing USDC (`aUSDC`) and Aave yield bearing USDT (`aUSDT`). Balancer V3 is architected to have the pool communicate it's reserves always in the base assets `DAI`, `USDC`, `USDT`. From a user perspective you simply get a Stablecoin pool with 100% yield bearing components. Any drawbacks such as complicated swap-paths, expensive wrapping & unwrapping, liquidity exploration via aggregators is solved on a higher level Balancer V3 smart contract architecture.
+Balancer V3 boosted pools allow for 100% of an LP position to be considered boosted, meaning held in a yield-bearing token. Prominent examples include bb-a-USD, which is a StablePool containing Aave yield-bearing DAI (`aDAI`), Aave yield-bearing USDC (`aUSDC`) and Aave yield-bearing USDT (`aUSDT`). The Balancer BatchRouter can handle user requests to trade among all these assets in a seamless and gas efficient manner (e.g., depositing and withdrawing underlying tokens DAI, USDC and USDT). The front end or aggregator can construct a batch swap with everything the router needs to perform the operations, including interacting with liquidity buffers (see below), and only wrapping or unwrapping when absolutely necessary.
 
 #### Gas efficient swaps between boosted pool's base assets
 Boosted pools leverage the Vault's [liquidity buffers](/concepts/vault/buffer.html#erc4626-liquidity-buffers) concept to facilitate gas-efficient swaps between boosted pools. This allows LPs to maintain 100% boosted pool positions and still earn swap fees from base-asset to base-asset trades.


### PR DESCRIPTION
This still had language left over from when buffers were pools, and we "hid" wrapped tokens from users. Some other more minor language edits.