### PR TITLE
Guides, onchain query warnings review

### DIFF
--- a/docs/integration-guides/guides/add-liquidity-to-pool.md
+++ b/docs/integration-guides/guides/add-liquidity-to-pool.md
@@ -293,7 +293,7 @@ const tx = await router.addLiquidityUnbalanced(
 
 The following code snippet shows how to add liquidity from a smart contract.
 
-::: warning Queries cannot be used within the same block to set minBptAmountOut due to possible manipulation
+::: warning Queries should not be used onchain to set minAmountOut due to possible manipulation via frontrunning.
 :::
 
 ```solidity

--- a/docs/integration-guides/guides/remove-liquidity-from-pool.md
+++ b/docs/integration-guides/guides/remove-liquidity-from-pool.md
@@ -303,7 +303,7 @@ const tx = await router.removeLiquidityProportional(
 
 The following code snippet shows how to remove liquidity from a smart contract.
 
-::: warning Queries cannot be used within the same block to set minAmountsOut due to possible manipulation
+::: warning Queries should not be used onchain to set minAmountOut due to possible manipulation via frontrunning.
 :::
 
 ```solidity

--- a/docs/integration-guides/guides/swapping-custom-paths-with-router.md
+++ b/docs/integration-guides/guides/swapping-custom-paths-with-router.md
@@ -354,7 +354,7 @@ const tx = await router.swapSingleTokenExactIn(
 
 #### Solidity
 
-::: warning Queries cannot be used within the same block to set minAmountOut due to possible manipulation
+::: warning Queries should not be used onchain to set minAmountOut due to possible manipulation via frontrunning.
 :::
 
 ```solidity
@@ -584,7 +584,7 @@ const tx = await router.swapExactIn(
 
 #### Solidity
 
-::: warning Queries cannot be used within the same block to set minAmountOut due to possible manipulation
+::: warning Queries should not be used onchain to set minAmountOut due to possible manipulation via frontrunning.
 :::
 
 ```solidity

--- a/docs/integration-guides/guides/swaps-for-aggregators.md
+++ b/docs/integration-guides/guides/swaps-for-aggregators.md
@@ -58,7 +58,7 @@ swapFeePercentage =
 
 [Queries](../../concepts/router/queries.md) provide the ability to simulate an operation and find its result without executing a transaction. Balancer Routers provide a query for all state changing liquidity operations including single and multi-path swap functions, e.g. `querySwapSingleTokenExactIn`. The following sections link to examples showing how queries can be used.
 
-::: warning Note - for onchain integrations queries cannot be used to set limits within the same block due to possible manipulation
+::: warning Note - for onchain integrations queries should not be used to set limits due to possible manipulation via frontrunning.
 :::
 
 ### Single Swaps


### PR DESCRIPTION
Fixes #11

I changed the notes on using queries in a solidity context to compute minAmountOut for example. I changed it to that queries should not be used any time onchain due to possible manipulation via frontrunning. Why did I make that change:

- Remove in the same block because using queries onchain can be frontrun regardless if it is in the same block or not
- `quoteAndRevert` now allows to use queries onchain again as the revertData has the result.

