### PR TITLE
Bring Vault API up-to-date

### DIFF
--- a/docs/developer-reference/contracts/vault-api.md
+++ b/docs/developer-reference/contracts/vault-api.md
@@ -10,20 +10,26 @@ The [Router](../router/overview.html) is the primary entry-point for the Balance
 :::
 
 :::info Interacting with the Vault on-chain
-The  Ethereum Virtual Machine (EVM) imposes bytecode restrictions that limit the size of deployed contracts. In order to achieve the desired functionality, the Vault exceeds
+The Ethereum Virtual Machine (EVM) imposes bytecode restrictions that limit the size of deployed contracts. In order to achieve the desired functionality, the Vault exceeds
 the bytecode limit of 24.576 kb. To overcome this, the Vault inherits from OpenZeppelin's Proxy contract and leverages delegate calls,
 allowing for the vault to utilize the functionality of more than one deployed smart contract.
 
 When interacting with the Balancer Vault via solidity, it is recommended to cast the Vaults address to an `IVault`. You can find the interface [here](https://github.com/balancer/balancer-v3-monorepo/blob/main/pkg/interfaces/contracts/vault/IVault.sol).
 :::
 
+:::info Vault Explorer
+Because of the constraints imposed by the Proxy pattern, the Vault contract itself doesn't expose much to blockchain explorers like Etherscan. You can see the extended functions by visiting the `VaultExtension` and `VaultAdmin` contracts, but any direct call on those contracts will revert.
+
+To provide access to the Vault through Etherscan in a user-friendly manner, there is a Vault "wrapper" contract called the `VaultExplorer`. This contract allows calling all permissionless Vault functions (e.g., `getPoolTokens`) through Etherscan.
+:::
+
 ## Transient accounting
 ### unlock
 
 ```solidity
-function unlock(bytes calldata data) external payable returns (bytes memory result);
+function unlock(bytes calldata data) external returns (bytes memory result);
 ```
-This function creates a context for a sequence of operations, effectively "unlocking" the Vault. It performs a callback on `msg.sender` with arguments provided in `data`. The callback is `transient`, meaning all balances for the caller have to be settled at the end.
+This `Vault` function creates a context for a sequence of operations, effectively "unlocking" the Vault. It performs a callback on `msg.sender` with arguments provided in `data`. The callback is `transient`, meaning all balances for the caller have to be settled at the end.
 
 **Parameters:**
 
@@ -40,28 +46,31 @@ This function creates a context for a sequence of operations, effectively "unloc
 ### settle
 
 ```solidity
-function settle(IERC20 token) external returns (uint256 paid);
+function settle(IERC20 token, uint256 amountHint) external returns (uint256 credit);
 ```
-This function settles deltas for a token. This operation must be successful for the current lock to be released. It returns the amount paid during settlement.
+This `Vault` function settles deltas for a token. This operation must be successful for the current lock to be released. It returns the credit supplied by the Vault, which can be calculated as `min(reserveDifference, amountHint)`, where the reserve difference equals current balance of the token minus existing reserves of the token when the function is called.
+
+The purpose of the hint is to protect against "donation DDoS attacks," where someone sends extra tokens to the Vault during the transaction (e.g., using reentrancy), which otherwise would cause settlement to fail. If the `reserveDifference` > `amountHint`, any "extra" tokens will simply be absorbed by the Vault (and reflected in the reserves), and not affect settlement. (The tokens will not be recoverable, as in V2.)
 
 **Parameters:**
 
 | Name  | Type  | Description  |
 |---|---|---|
 | token  | IERC20  | Token's address  |
+| amountHint  | uint256  | Amount the caller expects to be credited  |
 
 **Returns:**
 
 | Name  | Type  | Description  |
 |---|---|---|
-| paid  | uint256  | Amount paid during settlement  |
+| credit  | uint256  | Amount credited to the caller for settlement  |
 
 ### sendTo
 
 ```solidity
 function sendTo(IERC20 token, address to, uint256 amount) external;
 ```
-This function sends tokens to a recipient. There is no inverse operation for this function. To cancel debts, transfer funds to the Vault and call `settle`.
+This `Vault` function sends tokens to a recipient. There is no inverse operation for this function. To cancel debts, transfer funds to the Vault and call `settle`.
 
 **Parameters:**
 
@@ -76,7 +85,7 @@ This function sends tokens to a recipient. There is no inverse operation for thi
 ```solidity
 function isUnlocked() external view returns (bool);
 ```
-This function returns True if the Vault is unlocked, false otherwise.
+This `VaultExtension` function returns True if the Vault is unlocked, false otherwise.
 
 **Returns:**
 
@@ -89,7 +98,7 @@ This function returns True if the Vault is unlocked, false otherwise.
 ```solidity
 function getNonzeroDeltaCount() external view returns (uint256);
 ```
-This function returns the count of non-zero deltas.
+This `VaultExtension` function returns the count of non-zero deltas.
 
 **Returns:**
 
@@ -102,7 +111,7 @@ This function returns the count of non-zero deltas.
 ```solidity
 function getTokenDelta(IERC20 token) external view returns (int256);
 ```
-This function retrieves the token delta for a specific user and token.
+This `VaultExtension` function retrieves the token delta for a specific user and token.
 
 **Parameters:**
 
@@ -121,7 +130,7 @@ This function retrieves the token delta for a specific user and token.
 ```solidity
 function getReservesOf(IERC20 token) external view returns (uint256);
 ```
-This function retrieves the reserve (i.e., total Vault balance) of a given token.
+This `VaultExtension` function retrieves the reserve (i.e., total Vault balance) of a given token.
 
 **Parameters:**
 
@@ -135,6 +144,30 @@ This function retrieves the reserve (i.e., total Vault balance) of a given token
 |---|---|---|
 |  | uint256  | The amount of reserves for the given token  |
 
+## Swaps
+### `swap`
+
+```solidity
+function swap(
+    SwapParams memory params
+) external returns (uint256 amountCalculatedRaw, uint256 amountInRaw, uint256 amountOutRaw);
+```
+This `Vault` function swaps tokens based on provided parameters. All parameters are given in raw token decimal encoding.
+
+**Parameters:**
+
+| Name  | Type  | Description  |
+|---|---|---|
+| params  | SwapParams  | Parameters for the swap operation  |
+
+**Returns:**
+
+| Name  | Type  | Description  |
+|---|---|---|
+| amountCalculatedRaw  | uint256  | Calculated swap amount  |
+| amountInRaw  | uint256  | Amount of input tokens for the swap  |
+| amountOutRaw  | uint256  | Amount of output tokens from the swap  |
+
 ## Add Liquidity
 ### addLiquidity
 
@@ -143,7 +176,7 @@ function addLiquidity(
     AddLiquidityParams memory params
 ) external returns (uint256[] memory amountsIn, uint256 bptAmountOut, bytes memory returnData);
 ```
-This function adds liquidity to a pool. Caution should be exercised when adding liquidity because the Vault has the capability to transfer tokens from any user, given that it holds all allowances. It returns the actual amounts of input tokens, the output pool token amount, and optional data with an encoded response from the pool.
+This `Vault` function adds liquidity to a pool. Caution should be exercised when adding liquidity because the Vault has the capability to transfer tokens from any user, given that it holds all allowances. It returns the actual amounts of input tokens, the output pool token amount, and optional data with an encoded response from the pool.
 
 **Parameters:**
 
@@ -167,7 +200,7 @@ function removeLiquidity(
     RemoveLiquidityParams memory params
 ) external returns (uint256 bptAmountIn, uint256[] memory amountsOut, bytes memory returnData);
 ```
-This function removes liquidity from a pool. Trusted routers can burn pool tokens belonging to any user and require no prior approval from the user. Untrusted routers require prior approval from the user. This is the only function allowed to call `_queryModeBalanceIncrease` (and only in a query context).
+This `Vault` function removes liquidity from a pool. Trusted routers can burn pool tokens belonging to any user and require no prior approval from the user. Untrusted routers require prior approval from the user. This is the only function allowed to call `_queryModeBalanceIncrease` (and only in a query context).
 
 **Parameters:**
 
@@ -183,37 +216,13 @@ This function removes liquidity from a pool. Trusted routers can burn pool token
 | amountsOut  | uint256[]  | Actual amounts of output tokens  |
 | returnData  | bytes  | Arbitrary (optional) data with encoded response from the pool  |
 
-## Swaps
-### `swap`
-
-```solidity
-function swap(
-    SwapParams memory params
-) external returns (uint256 amountCalculatedRaw, uint256 amountInRaw, uint256 amountOutRaw);
-```
-This function swaps tokens based on provided parameters. All parameters are given in raw token decimal encoding.
-
-**Parameters:**
-
-| Name  | Type  | Description  |
-|---|---|---|
-| params  | SwapParams  | Parameters for the swap operation  |
-
-**Returns:**
-
-| Name  | Type  | Description  |
-|---|---|---|
-| amountCalculatedRaw  | uint256  | Calculated swap amount  |
-| amountInRaw  | uint256  | Amount of input tokens for the swap  |
-| amountOutRaw  | uint256  | Amount of output tokens from the swap  |
-
 ## Pool information
 ### `getPoolTokenCountAndIndexOfToken`
 
 ```solidity
 function getPoolTokenCountAndIndexOfToken(address pool, IERC20 token) external view returns (uint256, uint256);
 ```
-This function gets the index of a token in a given pool. It reverts if the pool is not registered, or if the token does not belong to the pool.
+This `Vault` function gets the index of a token in a given pool. It reverts if the pool is not registered, or if the token does not belong to the pool.
 
 **Parameters:**
 
@@ -229,7 +238,191 @@ This function gets the index of a token in a given pool. It reverts if the pool 
 | tokenCount  | uint256  | Number of tokens in the pool  |
 | index  | uint256  | Index corresponding to the given token in the pool's token list  |
 
-## Buffers
+### `isPoolInitialized`
+
+```solidity
+function isPoolInitialized(address pool) external view returns (bool);
+```
+This `VaultExtension` function checks whether a pool is initialized.
+
+**Parameters:**
+
+| Name  | Type  | Description  |
+|---|---|---|
+| pool  | address  | Address of the pool to check  |
+
+**Returns:**
+
+| Name  | Type  | Description  |
+|---|---|---|
+|  | bool  | True if the pool is initialized, false otherwise  |
+
+### `getPoolTokens`
+
+```solidity
+function getPoolTokens(address pool) external view returns (IERC20[] memory);
+```
+This `VaultExtension` function gets the tokens registered to a pool.
+
+**Parameters:**
+
+| Name  | Type  | Description  |
+|---|---|---|
+| pool  | address  | Address of the pool  |
+
+**Returns:**
+
+| Name  | Type  | Description  |
+|---|---|---|
+| tokens  | IERC20[]  | List of tokens in the pool  |
+
+### `getPoolTokenRates`
+
+```solidity
+function getPoolTokenRates(address pool) external view returns (uint256[] memory);
+```
+This `VaultExtension` function retrieves the scaling factors from a pool's rate providers. Tokens without rate providers will always return FixedPoint.ONE (1e18).
+
+**Parameters:**
+
+| Name  | Type  | Description  |
+|---|---|---|
+| pool  | address  | The address of the pool  |
+
+**Returns:**
+
+| Name  | Type  | Description  |
+|---|---|---|
+|  | uint256[]  | The rate scaling factors from the pool's rate providers  |
+
+### `getPoolData`
+
+```solidity
+function getPoolData(address pool) external view returns (PoolData memory);
+```
+This `VaultExtension` function retrieves a PoolData structure, containing comprehensive information about the pool, including the PoolConfig, tokens, tokenInfo, balances, rates and scaling factors.
+
+**Parameters:**
+
+| Name  | Type  | Description  |
+|---|---|---|
+| pool  | address  | The address of the pool  |
+
+**Returns:**
+
+| Name  | Type  | Description  |
+|---|---|---|
+|  | PoolData  | A struct with data describing the current state of the pool |
+
+### `getPoolTokenInfo`
+
+```solidity
+function getPoolTokenInfo(
+    address pool
+)
+    external
+    view
+    returns (
+        IERC20[] memory tokens,
+        TokenInfo[] memory tokenInfo,
+        uint256[] memory balancesRaw,
+        uint256[] memory lastLiveBalances
+    );
+```
+This function gets the raw data for a pool: tokens, raw and last live balances.
+
+**Parameters:**
+
+| Name  | Type  | Description  |
+|---|---|---|
+| pool  | address  | Address of the pool  |
+
+**Returns:**
+
+| Name  | Type  | Description  |
+|---|---|---|
+| tokens  | IERC20[]  | The pool tokens, sorted in registration order |
+| tokenInfo  | TokenInfo[]  | Token info, sorted in token registration order  |
+| balancesRaw  | uint256[]  | Raw balances, sorted in token registration order  |
+| lastLiveBalances  | uint256[]  | Last saved live balances, sorted in token registration order  |
+
+### `getCurrentLiveBalances`
+
+```solidity
+function getCurrentLiveBalances(address pool) external view returns (uint256[] memory balancesLiveScaled18);
+```
+This `VaultExtension` function retrieves the current live balances: i.e., token balances after paying yield fees, applying decimal scaling and rates.
+
+**Parameters:**
+
+| Name  | Type  | Description  |
+|---|---|---|
+| pool  | address  | The address of the pool  |
+
+**Returns:**
+
+| Name  | Type  | Description  |
+|---|---|---|
+| balancesLiveScaled18 | uint256[]  | Current live balances, sorted in token registration order |
+
+### `getPoolConfig`
+
+```solidity
+function getPoolConfig(address pool) external view returns (PoolConfig memory);
+```
+This `VaultExtension` function gets the configuration parameters of a pool.
+
+**Parameters:**
+
+| Name  | Type  | Description  |
+|---|---|---|
+| pool  | address  | Address of the pool  |
+
+**Returns:**
+
+| Name  | Type  | Description  |
+|---|---|---|
+|  | PoolConfig  | Pool configuration  |
+
+### `getHooksConfig`
+
+```solidity
+function getHooksConfig(address pool) external view returns (HooksConfig memory);
+```
+This `VaultExtension` function gets the hooks configuration parameters of a pool.
+
+**Parameters:**
+
+| Name  | Type  | Description  |
+|---|---|---|
+| pool  | address  | Address of the pool  |
+
+**Returns:**
+
+| Name  | Type  | Description  |
+|---|---|---|
+|  | HooksConfig  | Hooks configuration  |
+
+### `getBptRate`
+
+```solidity
+function getBptRate(address pool) external view returns (uint256 rate);
+```
+This `VaultExtension` function gets the current bpt rate of a pool, by dividing the current invariant by the total supply of BPT.
+
+**Parameters:**
+
+| Name  | Type  | Description  |
+|---|---|---|
+| pool  | address  | Address of the pool  |
+
+**Returns:**
+
+| Name  | Type  | Description  |
+|---|---|---|
+| rate  | uint256  | BPT rate  |
+
+## Yield-bearing token buffers
 ### `erc4626BufferWrapOrUnwrap`
 
 ```solidity
@@ -237,7 +430,7 @@ function erc4626BufferWrapOrUnwrap(
     BufferWrapOrUnwrapParams memory params
 ) external returns (uint256 amountCalculatedRaw, uint256 amountInRaw, uint256 amountOutRaw);
 ```
-This function wraps/unwraps tokens based on provided parameters, using the buffer of the wrapped token when it has enough liquidity to avoid external calls. All parameters are given in raw token decimal encoding.
+This `Vault` function wraps/unwraps tokens based on provided parameters, using the buffer of the wrapped token when it has enough liquidity to avoid external calls. All parameters are given in raw token decimal encoding.
 
 **Parameters:**
 
@@ -253,26 +446,112 @@ This function wraps/unwraps tokens based on provided parameters, using the buffe
 | amountInRaw  | uint256  | Amount of input tokens for the swap  |
 | amountOutRaw  | uint256  | Amount of output tokens from the swap  |
 
-## Misc
-### `getVaultAdmin`
+### `pauseVaultBuffers`
 
 ```solidity
-function getVaultAdmin() external view returns (address);
+function pauseVaultBuffers() external;
 ```
-This function returns the Vault Admin contract address.
+This `VaultAdmin` function pauses native vault buffers globally. When buffers are paused, it's not possible to add liquidity or wrap/unwrap tokens using Vault's `erc4626BufferWrapOrUnwrap` primitive. However, it's still possible to remove liquidity. Currently it's not possible to pause vault buffers individually. This is a permissioned call.
 
-**Returns:**
+### `unpauseVaultBuffers`
+
+```solidity
+function unpauseVaultBuffers() external;
+```
+This `VaultAdmin` function unpauses native vault buffers globally. When buffers are paused, it's not possible to add liquidity or wrap/unwrap tokens using Vault's `erc4626BufferWrapOrUnwrap` primitive. However, it's still possible to remove liquidity. This is a permissioned call.
+
+### `addLiquidityToBuffer`
+
+```solidity
+function addLiquidityToBuffer(
+    IERC4626 wrappedToken,
+    uint256 amountUnderlyingRaw,
+    uint256 amountWrappedRaw,
+    address sharesOwner
+) external returns (uint256 issuedShares);
+```
+This `VaultAdmin` function adds liquidity to a yield-bearing token buffer (linear pool embedded in the vault).
+
+**Parameters:**
 
 | Name  | Type  | Description  |
 |---|---|---|
-|  | address  | The address of the Vault Admin contract  |
+| wrappedToken  | IERC4626  | Address of the wrapped token that implements IERC4626  |
+| amountUnderlyingRaw  | uint256  | Amount of underlying tokens that will be deposited into the buffer  |
+| amountWrappedRaw  | uint256  | Amount of wrapped tokens that will be deposited into the buffer  |
+| sharesOwner  | address  | Address of contract that will own the deposited liquidity. Only this contract will be able to remove liquidity from the buffer  |
 
+### `removeLiquidityFromBuffer`
+
+```solidity
+function removeLiquidityFromBuffer(
+    IERC4626 wrappedToken,
+    uint256 sharesToRemove,
+    address sharesOwner
+) external returns (uint256 removedUnderlyingBalanceRaw, uint256 removedWrappedBalanceRaw);
+```
+This `VaultAdmin` function removes liquidity from a yield-bearing token buffer (linear pool embedded in the vault). Only proportional exits are supported.
+
+**Parameters:**
+
+| Name  | Type  | Description  |
+|---|---|---|
+| wrappedToken  | IERC4626  | Address of the wrapped token that implements IERC4626  |
+| sharesToRemove  | uint256  | Amount of shares to remove from the buffer. Cannot be greater than sharesOwner total shares  |
+| sharesOwner  | address  | Address of contract that owns the deposited liquidity.  |
+
+### `getBufferOwnerShares`
+
+```solidity
+function getBufferOwnerShares(
+    IERC20 wrappedToken,
+    address liquidityOwner
+) external view returns (uint256 ownerShares);
+```
+This `VaultAdmin` function returns the shares (internal buffer BPT) of a liquidity owner: a user that deposited assets in the buffer.
+
+**Parameters:**
+
+| Name  | Type  | Description  |
+|---|---|---|
+| wrappedToken  | IERC20  | Address of the wrapped token that implements IERC4626  |
+| liquidityOwner  | address  | Address of the user that owns liquidity in the wrapped token's buffer  |
+
+### `getBufferTotalShares`
+
+```solidity
+function getBufferTotalShares(IERC20 wrappedToken) external view returns (uint256 bufferShares);
+```
+This `VaultAdmin` function returns the supply shares (internal buffer BPT) of the ERC4626 buffer.
+
+**Parameters:**
+
+| Name  | Type  | Description  |
+|---|---|---|
+| wrappedToken  | IERC20  | Address of the wrapped token that implements IERC4626  |
+
+### `getBufferBalance`
+
+```solidity
+function getBufferBalance(
+    IERC20 wrappedToken
+) external view returns (uint256 underlyingBalanceRaw, uint256 wrappedBalanceRaw);
+```
+This `VaultAdmin` function returns the amount of underlying and wrapped tokens deposited in the internal buffer of the vault.
+
+**Parameters:**
+
+| Name  | Type  | Description  |
+|---|---|---|
+| wrappedToken  | IERC20  | Address of the wrapped token that implements IERC4626  |
+
+## Authentication
 ### `getAuthorizer`
 
 ```solidity
 function getAuthorizer() external view returns (IAuthorizer);
 ```
-This function returns the Vault's Authorizer.
+This `Vault` function returns the Vault's Authorizer. It is in the main Vault for performance reasons.
 
 **Returns:**
 
@@ -280,31 +559,18 @@ This function returns the Vault's Authorizer.
 |---|---|---|
 |  | IAuthorizer  | Address of the authorizer  |
 
-### `getVaultExtension`
+### `setAuthorizer`
 
 ```solidity
-function getVaultExtension() external view returns (address);
+function setAuthorizer(IAuthorizer newAuthorizer) external;
 ```
-This function returns the Vault Extension address.
+This `VaultAdmin` function sets a new Authorizer for the Vault. This is a permissioned call. It emits an `AuthorizerChanged` event.
 
-**Returns:**
+**Parameters:**
 
 | Name  | Type  | Description  |
 |---|---|---|
-|  | address  | Address of the VaultExtension  |
-
-### `getProtocolFeeController`
-
-```solidity
-function getProtocolFeeController() external view returns (IProtocolFeeController);
-```
-This function returns the Protocol Fee Controller address.
-
-**Returns:**
-
-| Name  | Type  | Description  |
-|---|---|---|
-|  | IProtocolFeeController  | Address of the ProtocolFeeController  |
+| newAuthorizer  | IAuthorizer  | The new Authorizer for the Vault  |
 
 ## Pool registration
 ### `registerPool`
@@ -321,7 +587,7 @@ function registerPool(
     LiquidityManagement calldata liquidityManagement
 ) external;
 ```
-This function registers a pool, associating it with its factory and the tokens it manages.
+This `VaultExtension` function registers a pool, associating it with its factory and the tokens it manages.
 
 **Parameters:**
 
@@ -341,7 +607,7 @@ This function registers a pool, associating it with its factory and the tokens i
 ```solidity
 function isPoolRegistered(address pool) external view returns (bool);
 ```
-This function checks whether a pool is registered.
+This `VaultExtension` function checks whether a pool is registered.
 
 **Parameters:**
 
@@ -367,7 +633,7 @@ function initialize(
     bytes memory userData
 ) external returns (uint256 bptAmountOut);
 ```
-This function initializes a registered pool by adding liquidity; mints BPT tokens for the first time in exchange.
+This `VaultExtension` function initializes a registered pool by adding liquidity; mints BPT tokens for the first time in exchange.
 
 **Parameters:**
 
@@ -386,141 +652,13 @@ This function initializes a registered pool by adding liquidity; mints BPT token
 |---|---|---|
 | bptAmountOut  | uint256  | Output pool token amount  |
 
-## Pool information
-### `isPoolInitialized`
-
-```solidity
-function isPoolInitialized(address pool) external view returns (bool);
-```
-This function checks whether a pool is initialized.
-
-**Parameters:**
-
-| Name  | Type  | Description  |
-|---|---|---|
-| pool  | address  | Address of the pool to check  |
-
-**Returns:**
-
-| Name  | Type  | Description  |
-|---|---|---|
-|  | bool  | True if the pool is initialized, false otherwise  |
-
-### `getPoolTokens`
-
-```solidity
-function getPoolTokens(address pool) external view returns (IERC20[] memory);
-```
-This function gets the tokens registered to a pool.
-
-**Parameters:**
-
-| Name  | Type  | Description  |
-|---|---|---|
-| pool  | address  | Address of the pool  |
-
-**Returns:**
-
-| Name  | Type  | Description  |
-|---|---|---|
-| tokens  | IERC20[]  | List of tokens in the pool  |
-
-### `getPoolTokenInfo`
-
-```solidity
-function getPoolTokenInfo(
-    address pool
-)
-    external
-    view
-    returns (
-        IERC20[] memory tokens,
-        TokenInfo[] memory tokenInfo,
-        uint256[] memory balancesRaw,
-        uint256[] memory scalingFactors
-    );
-```
-This function gets the raw data for a pool: tokens, raw balances, scaling factors.
-
-**Parameters:**
-
-| Name  | Type  | Description  |
-|---|---|---|
-| pool  | address  | Address of the pool  |
-
-**Returns:**
-
-| Name  | Type  | Description  |
-|---|---|---|
-| tokens  | IERC20[]  | The pool tokens, in registration order  |
-| tokenInfo  | TokenInfo[]  | Corresponding token info  |
-| balancesRaw  | uint256[]  | Corresponding raw balances of the tokens  |
-| scalingFactors  | uint256[]  | Corresponding scalingFactors of the tokens  |
-
-### `getPoolConfig`
-
-```solidity
-function getPoolConfig(address pool) external view returns (PoolConfig memory);
-```
-This function gets the configuration parameters of a pool.
-
-**Parameters:**
-
-| Name  | Type  | Description  |
-|---|---|---|
-| pool  | address  | Address of the pool  |
-
-**Returns:**
-
-| Name  | Type  | Description  |
-|---|---|---|
-|  | PoolConfig  | Pool configuration  |
-
-### `getHooksConfig`
-
-```solidity
-function getHooksConfig(address pool) external view returns (HooksConfig memory);
-```
-This function gets the hooks configuration parameters of a pool.
-
-**Parameters:**
-
-| Name  | Type  | Description  |
-|---|---|---|
-| pool  | address  | Address of the pool  |
-
-**Returns:**
-
-| Name  | Type  | Description  |
-|---|---|---|
-|  | HooksConfig  | Hooks configuration  |
-
-### `getBptRate`
-
-```solidity
-function getBptRate(address pool) external view returns (uint256 rate);
-```
-This function gets the current bpt rate of a pool, by dividing the current invariant by the total supply of BPT.
-
-**Parameters:**
-
-| Name  | Type  | Description  |
-|---|---|---|
-| pool  | address  | Address of the pool  |
-
-**Returns:**
-
-| Name  | Type  | Description  |
-|---|---|---|
-| rate  | uint256  | BPT rate  |
-
-## Pool tokens
+## Balancer Pool tokens
 ### `totalSupply`
 
 ```solidity
 function totalSupply(address token) external view returns (uint256);
 ```
-This function gets the total supply of a given ERC20 token.
+This `VaultExtension` function gets the total supply of a given ERC20 token.
 
 **Parameters:**
 
@@ -539,7 +677,7 @@ This function gets the total supply of a given ERC20 token.
 ```solidity
 function balanceOf(address token, address account) external view returns (uint256);
 ```
-This function gets the balance of an account for a given ERC20 token.
+This `VaultExtension` function gets the balance of an account for a given ERC20 token.
 
 **Parameters:**
 
@@ -559,7 +697,7 @@ This function gets the balance of an account for a given ERC20 token.
 ```solidity
 function allowance(address token, address owner, address spender) external view returns (uint256);
 ```
-This function gets the allowance of a spender for a given ERC20 token and owner.
+This `VaultExtension` function gets the allowance of a spender for a given ERC20 token and owner.
 
 **Parameters:**
 
@@ -575,12 +713,33 @@ This function gets the allowance of a spender for a given ERC20 token and owner.
 |---|---|---|
 |  | uint256  | Amount of tokens the spender is allowed to spend  |
 
+### `approve`
+
+```solidity
+function approve(address owner, address spender, uint256 amount) external returns (bool);
+```
+This `VaultExtension` function approves a spender to spend pool tokens on behalf of sender.
+
+**Parameters:**
+
+| Name  | Type  | Description  |
+|---|---|---|
+| owner  | address  | Owner's address  |
+| spender  | address  | Spender's address  |
+| amount  | uint256  | Amount of tokens to approve  |
+
+**Returns:**
+
+| Name  | Type  | Description  |
+|---|---|---|
+|  | bool  | True if successful, false otherwise  |
+
 ### `transfer`
 
 ```solidity
 function transfer(address owner, address to, uint256 amount) external returns (bool);
 ```
-This function transfers pool token from owner to a recipient.
+This `VaultExtension` function transfers pool token from owner to a recipient.
 
 **Parameters:**
 
@@ -601,7 +760,7 @@ This function transfers pool token from owner to a recipient.
 ```solidity
 function transferFrom(address spender, address from, address to, uint256 amount) external returns (bool);
 ```
-This function transfers pool token from a sender to a recipient using an allowance.
+This `VaultExtension` function transfers pool token from a sender to a recipient using an allowance.
 
 **Parameters:**
 
@@ -618,34 +777,13 @@ This function transfers pool token from a sender to a recipient using an allowan
 |---|---|---|
 |  | bool  | True if successful, false otherwise  |
 
-### `approve`
-
-```solidity
-function approve(address owner, address spender, uint256 amount) external returns (bool);
-```
-This function approves a spender to spend pool tokens on behalf of sender.
-
-**Parameters:**
-
-| Name  | Type  | Description  |
-|---|---|---|
-| owner  | address  | Owner's address  |
-| spender  | address  | Spender's address  |
-| amount  | uint256  | Amount of tokens to approve  |
-
-**Returns:**
-
-| Name  | Type  | Description  |
-|---|---|---|
-|  | bool  | True if successful, false otherwise  |
-
 ## pool pausing
 ### `isPoolPaused`
 
 ```solidity
 function isPoolPaused(address pool) external view returns (bool);
 ```
-This function indicates whether a pool is paused.
+This `VaultExtension` function indicates whether a pool is paused.
 
 **Parameters:**
 
@@ -664,7 +802,7 @@ This function indicates whether a pool is paused.
 ```solidity
 function getPoolPausedState(address pool) external view returns (bool, uint32, uint32, address);
 ```
-This function returns the paused status, and end times of the Pool's pause window and buffer period.
+This `VaultExtension` function returns the paused status, and end times of the Pool's pause window and buffer period.
 
 **Parameters:**
 
@@ -687,7 +825,7 @@ This function returns the paused status, and end times of the Pool's pause windo
 ```solidity
 function getAggregateSwapFeeAmount(address pool, IERC20 token) external view returns (uint256);
 ```
-This function returns the accumulated swap fees (including aggregate fees) in `token` collected by the pool.
+This `VaultExtension` function returns the accumulated swap fees (including aggregate fees) in `token` collected by the pool.
 
 **Parameters:**
 
@@ -707,7 +845,7 @@ This function returns the accumulated swap fees (including aggregate fees) in `t
 ```solidity
 function getAggregateYieldFeeAmount(address pool, IERC20 token) external view returns (uint256);
 ```
-This function returns the accumulated yield fees (including aggregate fees) in `token` collected by the pool.
+This `VaultExtension` function returns the accumulated yield fees (including aggregate fees) in `token` collected by the pool.
 
 **Parameters:**
 
@@ -727,7 +865,7 @@ This function returns the accumulated yield fees (including aggregate fees) in `
 ```solidity
 function getStaticSwapFeePercentage(address pool) external view returns (uint256);
 ```
-This function fetches the static swap fee percentage for a given pool.
+This `VaultExtension` function fetches the static swap fee percentage for a given pool.
 
 **Parameters:**
 
@@ -746,7 +884,7 @@ This function fetches the static swap fee percentage for a given pool.
 ```solidity
 function getPoolRoleAccounts(address pool) external view returns (PoolRoleAccounts memory);
 ```
-This function fetches the role accounts for a given pool (pause manager, swap manager, pool creator).
+This `VaultExtension` function fetches the role accounts for a given pool (pause manager, swap manager, pool creator).
 
 **Parameters:**
 
@@ -768,7 +906,7 @@ function computeDynamicSwapFee(
     IBasePool.PoolSwapParams memory swapParams
 ) external view returns (bool, uint256);
 ```
-This function queries the current dynamic swap fee of a pool, given a set of swap parameters.
+This `VaultExtension` function queries the current dynamic swap fee of a pool, given a set of swap parameters.
 
 **Parameters:**
 
@@ -784,13 +922,94 @@ This function queries the current dynamic swap fee of a pool, given a set of swa
 | success  | bool  | True if the pool has a dynamic swap fee and it can be successfully computed  |
 | dynamicSwapFee  | uint256  | The dynamic swap fee percentage  |
 
+### `getProtocolFeeController`
+
+```solidity
+function getProtocolFeeController() external view returns (IProtocolFeeController);
+```
+This `VaultExtension` function returns the Protocol Fee Controller address.
+
+**Returns:**
+
+| Name  | Type  | Description  |
+|---|---|---|
+|  | IProtocolFeeController  | Address of the ProtocolFeeController  |
+
+### `setStaticSwapFeePercentage`
+
+```solidity
+function setStaticSwapFeePercentage(address pool, uint256 swapFeePercentage) external;
+```
+This `VaultAdmin` function assigns a new static swap fee percentage to the specified pool. This is a permissioned function, disabled if the pool is paused. The swap fee percentage must be within the bounds specified by the pool's implementation of `ISwapFeePercentageBounds`.
+
+**Parameters:**
+
+| Name  | Type  | Description  |
+|---|---|---|
+| pool  | address  | The address of the pool for which the static swap fee will be changed  |
+| swapFeePercentage  | uint256  | The new swap fee percentage to apply to the pool  |
+
+### `collectAggregateFees`
+
+```solidity
+function collectAggregateFees(address pool) external;
+```
+This `VaultAdmin` function collects accumulated aggregate swap and yield fees for the specified pool. Fees are sent to the ProtocolFeeController address.
+
+**Parameters:**
+
+| Name  | Type  | Description  |
+|---|---|---|
+| pool  | address  | The pool on which all aggregate fees should be collected  |
+
+### `updateAggregateSwapFeePercentage`
+
+```solidity
+function updateAggregateSwapFeePercentage(address pool, uint256 newAggregateSwapFeePercentage) external;
+```
+This `VaultAdmin` function updates an aggregate swap fee percentage. Can only be called by the current protocol fee controller.
+
+**Parameters:**
+
+| Name  | Type  | Description  |
+|---|---|---|
+| pool  | address  | The pool whose fee will be updated  |
+| newAggregateSwapFeePercentage  | uint256  | The new aggregate swap fee percentage  |
+
+### `updateAggregateYieldFeePercentage`
+
+```solidity
+function updateAggregateYieldFeePercentage(address pool, uint256 newAggregateYieldFeePercentage) external;
+```
+This `VaultAdmin` function updates an aggregate yield fee percentage. Can only be called by the current protocol fee controller.
+
+**Parameters:**
+
+| Name  | Type  | Description  |
+|---|---|---|
+| pool  | address  | The pool whose fee will be updated  |
+| newAggregateYieldFeePercentage  | uint256  | The new aggregate yield fee percentage  |
+
+### `setProtocolFeeController`
+
+```solidity
+function setProtocolFeeController(IProtocolFeeController newProtocolFeeController) external;
+```
+This `VaultAdmin` function sets a new Protocol Fee Controller for the Vault. This is a permissioned call.
+
+**Parameters:**
+
+| Name  | Type  | Description  |
+|---|---|---|
+| newProtocolFeeController  | IProtocolFeeController  | The new Protocol Fee Controller for the Vault  |
+
 ## Recovery mode
 ### `isPoolInRecoveryMode`
 
 ```solidity
 function isPoolInRecoveryMode(address pool) external view returns (bool);
 ```
-This function checks whether a pool is in recovery mode.
+This `VaultExtension` function checks whether a pool is in recovery mode.
 
 **Parameters:**
 
@@ -813,7 +1032,7 @@ function removeLiquidityRecovery(
     uint256 exactBptAmountIn
 ) external returns (uint256[] memory amountsOut);
 ```
-This function removes liquidity from a pool specifying exact pool tokens in, with proportional token amounts out. The request is implemented by the Vault without any interaction with the pool, ensuring that it works the same for all pools, and cannot be disabled by a new pool type.
+This `VaultExtension` function removes liquidity from a pool specifying exact pool tokens in, with proportional token amounts out. The request is implemented by the Vault without any interaction with the pool, ensuring that it works the same for all pools, and cannot be disabled by a new pool type.
 
 **Parameters:**
 
@@ -829,33 +1048,31 @@ This function removes liquidity from a pool specifying exact pool tokens in, wit
 |---|---|---|
 | amountsOut  | uint256[]  | Actual calculated amounts of output tokens, sorted in token registration order  |
 
-## Buffer operations
-### `calculateBufferAmounts`
+### `enableRecoveryMode`
 
 ```solidity
-function calculateBufferAmounts(
-    SwapKind kind,
-    IERC4626 wrappedToken,
-    uint256 amountGiven
-) external returns (uint256 amountCalculated, uint256 amountInUnderlying, uint256 amountOutWrapped);
+function enableRecoveryMode(address pool) external;
 ```
-This function calculates the buffer amounts for a given swap kind, wrapped token, and given amount.
+This `VaultAdmin` function enables recovery mode for a pool. This is a permissioned function.
 
 **Parameters:**
 
 | Name  | Type  | Description  |
 |---|---|---|
-| kind  | SwapKind  | The kind of swap (in or out)  |
-| wrappedToken  | IERC4626  | The wrapped token involved in the swap  |
-| amountGiven  | uint256  | The amount given for the swap  |
+| pool  | address  | The pool  |
 
-**Returns:**
+### `disableRecoveryMode`
+
+```solidity
+function disableRecoveryMode(address pool) external;
+```
+This `VaultAdmin` function disables recovery mode for a pool. This is a permissioned function.
+
+**Parameters:**
 
 | Name  | Type  | Description  |
 |---|---|---|
-| amountCalculated  | uint256  | The calculated amount for the swap  |
-| amountInUnderlying  | uint256  | The amount in the underlying token  |
-| amountOutWrapped  | uint256  | The amount in the wrapped token  |
+| pool  | address  | The pool  |
 
 ## Queries
 ### `quote`
@@ -863,7 +1080,7 @@ This function calculates the buffer amounts for a given swap kind, wrapped token
 ```solidity
 function quote(bytes calldata data) external payable returns (bytes memory result);
 ```
-This function performs a callback on `msg.sender` with arguments provided in `data`. It is used to query a set of operations on the Vault. Only off-chain `eth_call` are allowed, anything else will revert.
+This `VaultExtension` function performs a callback on `msg.sender` with arguments provided in `data`. It is used to query a set of operations on the Vault. Only off-chain `eth_call` are allowed, anything else will revert.
 
 **Parameters:**
 
@@ -882,7 +1099,7 @@ This function performs a callback on `msg.sender` with arguments provided in `da
 ```solidity
 function quoteAndRevert(bytes calldata data) external payable;
 ```
-This function performs a callback on `msg.sender` with arguments provided in `data`. It is used to query a set of operations on the Vault. Only off-chain `eth_call` are allowed, anything else will revert. This call always reverts, returning the result in the revert reason.
+This `VaultExtension` function performs a callback on `msg.sender` with arguments provided in `data`. It is used to query a set of operations on the Vault. Only off-chain `eth_call` are allowed, anything else will revert. This call always reverts, returning the result in the revert reason.
 
 **Parameters:**
 
@@ -895,7 +1112,7 @@ This function performs a callback on `msg.sender` with arguments provided in `da
 ```solidity
 function isQueryDisabled() external view returns (bool);
 ```
-This function checks if the queries are enabled on the Vault.
+This `VaultExtension` function checks if the queries are enabled on the Vault.
 
 **Returns:**
 
@@ -903,13 +1120,47 @@ This function checks if the queries are enabled on the Vault.
 |---|---|---|
 |  | bool  | If true, then queries are disabled  |
 
+### `calculateBufferAmounts`
+
+```solidity
+function calculateBufferAmounts(
+    SwapKind kind,
+    IERC4626 wrappedToken,
+    uint256 amountGiven
+) external returns (uint256 amountCalculated, uint256 amountInUnderlying, uint256 amountOutWrapped);
+```
+This `VaultExtension` function calculates the buffer amounts for a given swap kind, wrapped token, and given amount.
+
+**Parameters:**
+
+| Name  | Type  | Description  |
+|---|---|---|
+| kind  | SwapKind  | The kind of swap (in or out)  |
+| wrappedToken  | IERC4626  | The wrapped token involved in the swap  |
+| amountGiven  | uint256  | The amount given for the swap  |
+
+**Returns:**
+
+| Name  | Type  | Description  |
+|---|---|---|
+| amountCalculated  | uint256  | The calculated amount for the swap  |
+| amountInUnderlying  | uint256  | The amount in the underlying token  |
+| amountOutWrapped  | uint256  | The amount in the wrapped token  |
+
+### `disableQuery`
+
+```solidity
+function disableQuery() external;
+```
+This `VaultAdmin` function disables queries functionality on the Vault. It can only be called by governance.
+
 ## Constants
 ### `getPauseWindowEndTime`
 
 ```solidity
 function getPauseWindowEndTime() external view returns (uint32);
 ```
-This function returns Vault's pause window end time.
+This `VaultAdmin` function returns Vault's pause window end time.
 
 **Returns:**
 
@@ -922,7 +1173,7 @@ This function returns Vault's pause window end time.
 ```solidity
 function getBufferPeriodDuration() external view returns (uint32);
 ```
-This function returns Vault's buffer period duration.
+This `VaultAdmin` function returns Vault's buffer period duration.
 
 **Returns:**
 
@@ -935,7 +1186,7 @@ This function returns Vault's buffer period duration.
 ```solidity
 function getBufferPeriodEndTime() external view returns (uint32);
 ```
-This function returns Vault's buffer period end time.
+This `VaultAdmin` function returns Vault's buffer period end time.
 
 **Returns:**
 
@@ -948,7 +1199,7 @@ This function returns Vault's buffer period end time.
 ```solidity
 function getMinimumPoolTokens() external pure returns (uint256);
 ```
-This function gets the minimum number of tokens in a pool.
+This `VaultAdmin` function gets the minimum number of tokens in a pool.
 
 **Returns:**
 
@@ -961,7 +1212,7 @@ This function gets the minimum number of tokens in a pool.
 ```solidity
 function getMaximumPoolTokens() external pure returns (uint256);
 ```
-This function gets the maximum number of tokens in a pool.
+This `VaultAdmin` function gets the maximum number of tokens in a pool.
 
 **Returns:**
 
@@ -974,33 +1225,13 @@ This function gets the maximum number of tokens in a pool.
 ```solidity
 function vault() external view returns (IVault);
 ```
-This function returns the main Vault address.
+This function (defined on both `VaultExtension` and `VaultAdmin`) returns the main Vault address.
 
 **Returns:**
 
 | Name  | Type  | Description  |
 |---|---|---|
 |  | IVault  | The main Vault address  |
-
-## Pool information
-### `getPoolTokenRates`
-
-```solidity
-function getPoolTokenRates(address pool) external view returns (uint256[] memory);
-```
-This function retrieves the scaling factors from a pool's rate providers. Tokens without rate providers will always return FixedPoint.ONE (1e18).
-
-**Parameters:**
-
-| Name  | Type  | Description  |
-|---|---|---|
-| pool  | address  | The address of the pool  |
-
-**Returns:**
-
-| Name  | Type  | Description  |
-|---|---|---|
-|  | uint256[]  | The scaling factors from the pool's rate providers  |
 
 ## Vault pausing
 
@@ -1009,7 +1240,7 @@ This function retrieves the scaling factors from a pool's rate providers. Tokens
 ```solidity
 function isVaultPaused() external view returns (bool);
 ```
-This function indicates whether the Vault is paused.
+This `VaultAdmin` function indicates whether the Vault is paused.
 
 **Returns:**
 
@@ -1022,7 +1253,7 @@ This function indicates whether the Vault is paused.
 ```solidity
 function getVaultPausedState() external view returns (bool, uint32, uint32);
 ```
-This function returns the paused status, and end times of the Vault's pause window and buffer period.
+This `VaultAdmin` function returns the paused status, and end times of the Vault's pause window and buffer period.
 
 **Returns:**
 
@@ -1037,14 +1268,14 @@ This function returns the paused status, and end times of the Vault's pause wind
 ```solidity
 function pauseVault() external;
 ```
-This function pauses the Vault: an emergency action which disables all operational state-changing functions. This is a permissioned function that will only work during the Pause Window set during deployment.
+This `VaultAdmin` function pauses the Vault: an emergency action which disables all operational state-changing functions. This is a permissioned function that will only work during the Pause Window set during deployment.
 
 ### `unpauseVault`
 
 ```solidity
 function unpauseVault() external;
 ```
-This function reverses a `pause` operation, and restores the Vault to normal functionality. This is a permissioned function that will only work on a paused Vault within the Buffer Period set during deployment. Note that the Vault will automatically unpause after the Buffer Period expires.
+This `VaultAdmin` function reverses a `pause` operation, and restores the Vault to normal functionality. This is a permissioned function that will only work on a paused Vault within the Buffer Period set during deployment. Note that the Vault will automatically unpause after the Buffer Period expires.
 
 ## Pool pausing
 ### `pausePool`
@@ -1052,7 +1283,7 @@ This function reverses a `pause` operation, and restores the Vault to normal fun
 ```solidity
 function pausePool(address pool) external;
 ```
-This function pauses the Pool: an emergency action which disables all pool functions. This is a permissioned function that will only work during the Pause Window set during pool factory deployment.
+This `VaultAdmin` function pauses the Pool: an emergency action which disables all pool functions. This is a permissioned function that will only work during the Pause Window set during pool factory deployment.
 
 **Parameters:**
 
@@ -1065,7 +1296,7 @@ This function pauses the Pool: an emergency action which disables all pool funct
 ```solidity
 function unpausePool(address pool) external;
 ```
-This function reverses a `pause` operation, and restores the Pool to normal functionality. This is a permissioned function that will only work on a paused Pool within the Buffer Period set during deployment. Note that the Pool will automatically unpause after the Buffer Period expires.
+This `VaultAdmin` function reverses a `pause` operation, and restores the Pool to normal functionality. This is a permissioned function that will only work on a paused Pool within the Buffer Period set during deployment. Note that the Pool will automatically unpause after the Buffer Period expires.
 
 **Parameters:**
 
@@ -1073,223 +1304,32 @@ This function reverses a `pause` operation, and restores the Pool to normal func
 |---|---|---|
 | pool  | address  | The address of the pool  |
 
-## Fees
-### `setStaticSwapFeePercentage`
+## Miscellaneous
+### `getVaultExtension`
 
 ```solidity
-function setStaticSwapFeePercentage(address pool, uint256 swapFeePercentage) external;
+function getVaultExtension() external view returns (address);
 ```
-This function assigns a new static swap fee percentage to the specified pool. This is a permissioned function, disabled if the pool is paused. The swap fee percentage must be within the bounds specified by the pool's implementation of `ISwapFeePercentageBounds`.
+This `Vault` function returns the Vault Extension address.
 
-**Parameters:**
+**Returns:**
 
 | Name  | Type  | Description  |
 |---|---|---|
-| pool  | address  | The address of the pool for which the static swap fee will be changed  |
-| swapFeePercentage  | uint256  | The new swap fee percentage to apply to the pool  |
+|  | address  | Address of the VaultExtension  |
 
-### `collectAggregateFees`
+### `getVaultAdmin`
 
 ```solidity
-function collectAggregateFees(address pool) external;
+function getVaultAdmin() external view returns (address);
 ```
-This function collects accumulated aggregate swap and yield fees for the specified pool. Fees are sent to the ProtocolFeeController address.
+This `VaultExtension` function returns the Vault Admin contract address.
 
-**Parameters:**
+**Returns:**
 
 | Name  | Type  | Description  |
 |---|---|---|
-| pool  | address  | The pool on which all aggregate fees should be collected  |
-
-### `updateAggregateSwapFeePercentage`
-
-```solidity
-function updateAggregateSwapFeePercentage(address pool, uint256 newAggregateSwapFeePercentage) external;
-```
-This function updates an aggregate swap fee percentage. Can only be called by the current protocol fee controller.
-
-**Parameters:**
-
-| Name  | Type  | Description  |
-|---|---|---|
-| pool  | address  | The pool whose fee will be updated  |
-| newAggregateSwapFeePercentage  | uint256  | The new aggregate swap fee percentage  |
-
-### `updateAggregateYieldFeePercentage`
-
-```solidity
-function updateAggregateYieldFeePercentage(address pool, uint256 newAggregateYieldFeePercentage) external;
-```
-This function updates an aggregate yield fee percentage. Can only be called by the current protocol fee controller.
-
-**Parameters:**
-
-| Name  | Type  | Description  |
-|---|---|---|
-| pool  | address  | The pool whose fee will be updated  |
-| newAggregateYieldFeePercentage  | uint256  | The new aggregate yield fee percentage  |
-
-### `setProtocolFeeController`
-
-```solidity
-function setProtocolFeeController(IProtocolFeeController newProtocolFeeController) external;
-```
-This function sets a new Protocol Fee Controller for the Vault. This is a permissioned call.
-
-**Parameters:**
-
-| Name  | Type  | Description  |
-|---|---|---|
-| newProtocolFeeController  | IProtocolFeeController  | The new Protocol Fee Controller for the Vault  |
-
-## Recovery mode
-### `enableRecoveryMode`
-
-```solidity
-function enableRecoveryMode(address pool) external;
-```
-This function enables recovery mode for a pool. This is a permissioned function.
-
-**Parameters:**
-
-| Name  | Type  | Description  |
-|---|---|---|
-| pool  | address  | The pool  |
-
-### `disableRecoveryMode`
-
-```solidity
-function disableRecoveryMode(address pool) external;
-```
-This function disables recovery mode for a pool. This is a permissioned function.
-
-**Parameters:**
-
-| Name  | Type  | Description  |
-|---|---|---|
-| pool  | address  | The pool  |
-
-## Queries
-### `disableQuery`
-
-```solidity
-function disableQuery() external;
-```
-This function disables queries functionality on the Vault. It can only be called by governance.
-
-## Buffers
-### `unpauseVaultBuffers`
-
-```solidity
-function unpauseVaultBuffers() external;
-```
-This function unpauses native vault buffers globally. When buffers are paused, it's not possible to add liquidity or wrap/unwrap tokens using Vault's `erc4626BufferWrapOrUnwrap` primitive. However, it's still possible to remove liquidity. This is a permissioned call.
-
-### `pauseVaultBuffers`
-
-```solidity
-function pauseVaultBuffers() external;
-```
-This function pauses native vault buffers globally. When buffers are paused, it's not possible to add liquidity or wrap/unwrap tokens using Vault's `erc4626BufferWrapOrUnwrap` primitive. However, it's still possible to remove liquidity. Currently it's not possible to pause vault buffers individually. This is a permissioned call.
-
-### `addLiquidityToBuffer`
-
-```solidity
-function addLiquidityToBuffer(
-    IERC4626 wrappedToken,
-    uint256 amountUnderlyingRaw,
-    uint256 amountWrappedRaw,
-    address sharesOwner
-) external returns (uint256 issuedShares);
-```
-This function adds liquidity to a yield-bearing token buffer (linear pool embedded in the vault).
-
-**Parameters:**
-
-| Name  | Type  | Description  |
-|---|---|---|
-| wrappedToken  | IERC4626  | Address of the wrapped token that implements IERC4626  |
-| amountUnderlyingRaw  | uint256  | Amount of underlying tokens that will be deposited into the buffer  |
-| amountWrappedRaw  | uint256  | Amount of wrapped tokens that will be deposited into the buffer  |
-| sharesOwner  | address  | Address of contract that will own the deposited liquidity. Only this contract will be able to remove liquidity from the buffer  |
-
-### `removeLiquidityFromBuffer`
-
-```solidity
-function removeLiquidityFromBuffer(
-    IERC4626 wrappedToken,
-    uint256 sharesToRemove,
-    address sharesOwner
-) external returns (uint256 removedUnderlyingBalanceRaw, uint256 removedWrappedBalanceRaw);
-```
-This function removes liquidity from a yield-bearing token buffer (linear pool embedded in the vault). Only proportional exits are supported.
-
-**Parameters:**
-
-| Name  | Type  | Description  |
-|---|---|---|
-| wrappedToken  | IERC4626  | Address of the wrapped token that implements IERC4626  |
-| sharesToRemove  | uint256  | Amount of shares to remove from the buffer. Cannot be greater than sharesOwner total shares  |
-| sharesOwner  | address  | Address of contract that owns the deposited liquidity.  |
-
-### `getBufferOwnerShares`
-
-```solidity
-function getBufferOwnerShares(
-    IERC20 wrappedToken,
-    address liquidityOwner
-) external view returns (uint256 ownerShares);
-```
-This function returns the shares (internal buffer BPT) of a liquidity owner: a user that deposited assets in the buffer.
-
-**Parameters:**
-
-| Name  | Type  | Description  |
-|---|---|---|
-| wrappedToken  | IERC20  | Address of the wrapped token that implements IERC4626  |
-| liquidityOwner  | address  | Address of the user that owns liquidity in the wrapped token's buffer  |
-
-### `getBufferTotalShares`
-
-```solidity
-function getBufferTotalShares(IERC20 wrappedToken) external view returns (uint256 bufferShares);
-```
-This function returns the supply shares (internal buffer BPT) of the ERC4626 buffer.
-
-**Parameters:**
-
-| Name  | Type  | Description  |
-|---|---|---|
-| wrappedToken  | IERC20  | Address of the wrapped token that implements IERC4626  |
-
-### `getBufferBalance`
-
-```solidity
-function getBufferBalance(
-    IERC20 wrappedToken
-) external view returns (uint256 underlyingBalanceRaw, uint256 wrappedBalanceRaw);
-```
-This function returns the amount of underlying and wrapped tokens deposited in the internal buffer of the vault.
-
-**Parameters:**
-
-| Name  | Type  | Description  |
-|---|---|---|
-| wrappedToken  | IERC20  | Address of the wrapped token that implements IERC4626  |
-
-## Authentication
-### `setAuthorizer`
-
-```solidity
-function setAuthorizer(IAuthorizer newAuthorizer) external;
-```
-This function sets a new Authorizer for the Vault. This is a permissioned call. It emits an `AuthorizerChanged` event.
-
-**Parameters:**
-
-| Name  | Type  | Description  |
-|---|---|---|
-| newAuthorizer  | IAuthorizer  | The new Authorizer for the Vault  |
+|  | address  | The address of the Vault Admin contract  |
 
 <style scoped>
 table {


### PR DESCRIPTION
We've changed a few functions (e.g., unlock, settle) since this was written, so it first brings those functions up to match the current code.

Also, we mention the `VaultExplorer`, which can be used to access functions through Etherscan that would otherwise not be visible (or revert if called directly).

Finally, it unifies the entire Vault interface under common headings - but identifies which actual contract the function is in (e.g., "this `VaultExtension` function...")

The diff is pretty rough, because of the reordering. Probably best to just look at the rendered result.