### PR TITLE
Raise the limit to 8 tokens

### DIFF
--- a/docs/concepts/explore-available-balancer-pools/stable-pool/stable-pool.md
+++ b/docs/concepts/explore-available-balancer-pools/stable-pool/stable-pool.md
@@ -12,6 +12,11 @@ references:
 
 Stable Pools are designed for assets that are either expected to consistently swap at near parity, or at a known exchange rate. Stable Pools use [Stable Math](./stable-math.md) (based on StableSwap, popularized by Curve) which allows for swaps of significant size before encountering substantial price impact, vastly increasing capital efficiency for like-kind and correlated-kind swaps.
 
+::: info info
+Balancer v3 pools are limited at the Vault level to 8 tokens. Stable Pools have a safe maximum of 5 tokens, due to the constraints of Stable Math (same as in v2).
+Standard Stable Pools support 5 tokens.
+:::
+
 ### Ideal For
 
 - **Pegged Tokens** - tokens that swap near 1:1, such as two stablecoins of the same currency (eg: DAI, USDC, USDT), or synthetic assets (eg: renBTC, sBTC, WBTC)

--- a/docs/concepts/explore-available-balancer-pools/weighted-pool/weighted-pool.md
+++ b/docs/concepts/explore-available-balancer-pools/weighted-pool/weighted-pool.md
@@ -13,7 +13,7 @@ references:
 Weighted Pools are an extension of the classical $x * y = k$ AMM pools popularized by Uniswap v1. Weighted Pools use [Weighted Math](./weighted-math.md), which makes them great for general cases, including tokens that don't necessarily have any price correlation (ex. DAI/WETH). Unlike pools in other AMMs that only provide 50/50 weightings, Balancer Weighted Pools enable users to build pools with more than two tokens and custom weights, such as pools with 80/20 or 60/20/20 weights.
 
 ::: info info
-For performance reasons, Balancer v3 pools are limited at the Vault level to 4 tokens.
+Balancer v3 pools are limited at the Vault level to 8 tokens, and Standard Weighted Pools support any token count up to this limit.
 Weighted Pools have additional security constraints based on Weighted Math. (These are the same as in v2.)
 
 - The minimum token weight is 1%


### PR DESCRIPTION
We are raising the token limit from 4 to 8 in the Vault. (See https://github.com/balancer/balancer-v3-monorepo/pull/788). There will be follow-on PRs to bring Weighted Pools up to 8 tokens, and Stable Pools up to 5, so that everything matches v2.

Can wait to merge this until those PRs are merged.