### PR TITLE
Initialize hooks are now non-reentrant

### DIFF
--- a/docs/concepts/core-concepts/hooks.md
+++ b/docs/concepts/core-concepts/hooks.md
@@ -29,7 +29,7 @@ Hooks are implemented as standalone contracts that can have their own internal l
 - `onAfterSwap`
 - `onComputeDynamicSwapFeePercentage`
 
-Refer to the [Pool hooks API](/developer-reference/contracts/hooks-api.html) page for full function references.
+Refer to the [Pool hooks API](/developer-reference/contracts/hooks-api.html) page for full function references. The swap, liquidity, and dynamic swap fee hooks are reentrant (i.e., you can call additional Vault operations during them, such as a swap after adding liquidity).
 
 Each Hook contract must implement the `getHookFlags` function which returns a `HookFlags` indicating which hooks are supported:
 ```solidity

--- a/docs/developer-reference/contracts/hooks-api.md
+++ b/docs/developer-reference/contracts/hooks-api.md
@@ -51,7 +51,7 @@ Returns flags informing which hooks are implemented in the contract.
 ```solidity
 function onBeforeInitialize(uint256[] memory exactAmountsIn, bytes memory userData) external returns (bool);
 ```
-Optional hook to be executed before pool initialization.
+Optional hook to be executed before pool initialization. Note that unlike the swap and liquidity hooks, the initialize hooks are non-reentrant.
 
 **Parameters:**
 
@@ -75,7 +75,7 @@ function onAfterInitialize(
     bytes memory userData
 ) external returns (bool);
 ```
-Optional hook to be executed after pool initialization.
+Optional hook to be executed after pool initialization. Note that unlike the swap and liquidity hooks, the initialize hooks are non-reentrant.
 
 **Parameters:**
 


### PR DESCRIPTION
This was an audit finding. We could have protected it specifically, but decided that initialization probably shouldn't be reentrant in the first place, and solved it that way.