### PR TITLE
Clarification for b-sdk usage for v2.

### DIFF
--- a/docs/integration-guides/add-and-remove-liquidity/add-liquidity-to-pool.md
+++ b/docs/integration-guides/add-and-remove-liquidity/add-liquidity-to-pool.md
@@ -7,7 +7,7 @@ title: Add liquidity to a pool
 
 This guide demonstrates how to add liquidity to a pool. We will use the `addLiquidityUnbalanced` method, since it allows exact amounts of any pool token to be added to a pool, avoiding unnecessary dust in the user's wallet. See the [Router API](/developer-reference/contracts/router-api.html) for other supported add methods.
 
-_This guide is for adding liquidity to Balancer v3. If you're looking to add liquidity to a Balancer v2 pool, start [here](https://docs.balancer.fi/guides/builders/join-pool.html)._
+_This guide is for adding liquidity to Balancer v3 with the [b-sdk](https://github.com/balancer/b-sdk). This sdk supports adding liquidity to Balancer v3, Balancer v2 as well as Cow-AMMs._
 
 ## Core Concepts
 

--- a/docs/integration-guides/add-and-remove-liquidity/remove-liquidity-from-pool.md
+++ b/docs/integration-guides/add-and-remove-liquidity/remove-liquidity-from-pool.md
@@ -7,7 +7,7 @@ title: Remove liquidity from a pool
 
 This guide demonstrates how to remove liquidity from a pool. We will use the preferred function for removing liquidity, `removeLiquidityProportional`. Tokens are removed from the pool in proportional amounts, causing zero price impact and avoiding the swap fee charged when exiting non-proportional. Specifying an exactBptAmountIn ensures that the user will not be left with any dust. See the [Router API](../router/overview.html) for other supported remove methods.
 
-_This guide is for removing liquidity to Balancer v3. If you're looking to remove liquidity from a Balancer v2 pool, start [here](https://docs.balancer.fi/guides/builders/exit-pool.html)._
+_This guide is for removing liquidity from Balancer v3 with the [b-sdk](https://github.com/balancer/b-sdk). This sdk supports removing liquidity from Balancer v3, Balancer v2 as well as Cow-AMMs._
 
 ## Core Concepts
 

--- a/docs/integration-guides/swapping/swapping-custom-paths-with-router.md
+++ b/docs/integration-guides/swapping/swapping-custom-paths-with-router.md
@@ -9,7 +9,7 @@ This guide illustrates the process of executing swaps through the router once sw
 
 _To use the Balancer Smart Order Router to find efficient swap paths for a pair see [this guide](./swaps-with-sor-sdk.md)._
 
-_This guide is for Swapping on Balancer v3. If you're looking to Swap using Balancer v2, start [here](https://docs.balancer.fi/reference/swaps/batch-swaps.html)._
+_This guide is for Swapping on Balancer v3. The sdk supports swapping on v3 and Balancer v2._
 
 ## Core Concepts
 


### PR DESCRIPTION
Fixes #175

> 
hey everyone, we would like to build txn for adding liq to some of our v2 pools on Balancer for an internal product and wanted to ask for guidance on which approach to use. when going through your v3 sdk docs (https://docs-v3.balancer.fi/integration-guides/add-and-remove-liquidity/add-liquidity-to-pool.html), it states it only handles the v3 pools and redirects to v2 sdk docs where i can handle v2 respectively (https://docs.balancer.fi/guides/builders/join-pool.html). this v2 sdk, however, is sometimes getting timed out because of too many requests which seems to be an obstacle on the sdk side. is there any way to bypass this (maybe by using some specific api key) to still be able to build these txns with the v2 sdk consistently?
