### PR TITLE
Fix deployments link

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -47,7 +47,7 @@ footer:
 **Github Repos**
 
 - [Smart Contracts](https://github.com/balancer/balancer-v3-monorepo)
-- [Deployments](https://github.com/balancer/pvt-deployments/tree/master)
+- [Deployments](https://github.com/balancer/balancer-deployments)
 - [SDK](https://github.com/balancer/balancer-sdk)
 - [API](https://github.com/balancer/backend)
 - [Frontend](https://github.com/balancer/frontend-monorepo)


### PR DESCRIPTION
Had a partner mention the "deployments"  link points at private repo

Also maybe we should consider an improvement to the homepage footer w/ links to socials, discover, etc?

#### Our Docs Footer
![image](https://github.com/user-attachments/assets/ffb4b37d-94d2-4a7d-b7bf-7d9d970c9ba8)

#### Other Docs Examples
![image](https://github.com/user-attachments/assets/feb83896-bb07-460e-984c-2bc1669539ff)

![image](https://github.com/user-attachments/assets/52d9fc1b-79df-492c-aea6-7a01a1d14fbf)
