### PR TITLE
Expand on supported tokens

### DIFF
--- a/docs/build/README.md
+++ b/docs/build/README.md
@@ -34,5 +34,9 @@ necessary organic flow to compete effectively.
 
 Our aim is to simplify the development process and facilitate the creation of novel AMMs with minimal friction.
 
+:::info
+When adding new tokens to Balancer pools, keep in mind the [Vault compatibility requirements](../partner-onboarding/onboarding-overview/core-pools.md#token-requirements).
+:::
+
 When building on Balancer, there are three paths to explore:
 

--- a/docs/partner-onboarding/onboarding-overview/core-pools.md
+++ b/docs/partner-onboarding/onboarding-overview/core-pools.md
@@ -33,8 +33,36 @@ Pools without proper protocol fee settings (e.g., CoWAMM v1 pools) cannot achiev
 ### Token Requirements
 
 - All pool tokens must have verified smart contracts
-- Tokens cannot have transfer restrictions
-- Tokens cannot implement rebasing mechanics
+
+In addition, the following token features are unsupported by the Vault. This list is not meant to be exhaustive, but covers many common types of tokens that will not work with the Vault architecture.
+(See https://github.com/d-xo/weird-erc20 for examples of features that are problematic for many protocols.)
+
+- Rebasing tokens (e.g., aDAI). The Vault keeps track of token balances in its internal accounting; any token whose balance changes asynchronously (i.e., outside a swap or liquidity operation),
+  would get out-of-sync with this internal accounting. This category would also include "airdrop" tokens, whose balances can change unexpectedly.
+
+- Double entrypoint tokens (e.g., old Synthetix tokens, now fixed). These could likewise bypass internal accounting by registering the token under one address, then accessing it through another.
+  This is especially troublesome in v3, with the introduction of ERC4626 buffers and transient accounting.
+
+- Fee on transfer tokens (e.g., PAXG). The Vault issues credits and debits according to given and calculated token amounts, and settlement assumes that the send/receive transfer functions transfer   
+  exactly the given number of tokens. If this is not the case, and the token itself imposes a "tax" on transfers, transactions will not settle. Unlike with the other types, which are fundamentally
+  incompatible, it would be possible to design a Router to handle this - but we didn't try it. In any case, it's not supported in the current Routers.
+
+- Tokens with more than 18 decimals (e.g., YAM-V2). The Vault handles token scaling: i.e., handling I/O for amounts in native token decimals, but doing calculations with full 18-decimal precision.
+  This requires reading and storing the decimals for each token. Since virtually all tokens are 18 or fewer decimals, and we have limited storage space, 18 was a reasonable maximum. Unlike the other types, this is enforceable by the Vault. Attempting to register such tokens will revert with `InvalidTokenDecimals`. Of course, we must also be able to read the token decimals, so the Vault only supports tokens that implement `IERC20Metadata.decimals`, and return a value less than or equal to 18.
+
+- Token decimals are checked and stored only once, on registration. Valid tokens store their decimals as immutable variables or constants. Malicious tokens that don't respect this basic property
+  would not work anywhere in DeFi.
+
+These types of tokens are technically supported but discouraged, as they don't tend to play well with AMMs generally.
+
+- Very low-decimal tokens (e.g., GUSD). The Vault has been extensively tested with 6-decimal tokens (e.g., USDC), but going much below that may lead to unanticipated effects due to precision loss,
+  especially with smaller trade values.
+
+- Revert on zero value approval/transfer. The Vault has been tested against these, but peripheral contracts, such as hooks, might not have been designed with this in mind.
+
+- Other types from "weird-erc20," such as upgradeable, pausable, or tokens with blocklists. We have seen cases where a token upgrade fails, "bricking" the token - and many operations on pools
+  containing that token. Any sort of "permissioned" token that can make transfers fail can cause operations on pools containing them to revert. Even Recovery Mode cannot help then, as it does a
+  proportional withdrawal of all tokens. If one of them is bricked, the whole operation will revert. Since v3 does not have "internal balances" like v2, there is no recourse.
 
 ## Core Pool Benefits
 

--- a/docs/partner-onboarding/onboarding-overview/introduction.md
+++ b/docs/partner-onboarding/onboarding-overview/introduction.md
@@ -32,8 +32,11 @@ Balancer Technology provides innovative AMM designs such as
 
 Onboarding into Balancer varies depending on the AMM technology you want to use. Some components are simple and straightforward to use, while others may require expert assistance from our core contributors.
 
-Learn more about our onboarding journey, use the Balancer Tech Product Wizard to find the best solution for your needs, or check out our product case studies  below.
+Learn more about our onboarding journey, use the Balancer Tech Product Wizard to find the best solution for your needs, or check out our product case studies below.
 
+:::info
+When adding new tokens to Balancer pools, keep in mind the [Vault compatibility requirements](../../partner-onboarding/onboarding-overview/core-pools.md#token-requirements).
+:::
 
 ### Onboarding Journey
 Onboarding your asset onto Balancer involves three main steps:


### PR DESCRIPTION
We have extensive documentation on supported and unsupported tokens in the code, but it was fairly lacking in the public docs. This adds a section about it, and links to it from a couple relevant sections.