### PR TITLE
Fix Routers deployment addresses in optimism.md

### DIFF
--- a/docs/developer-reference/contracts/deployment-addresses/optimism.md
+++ b/docs/developer-reference/contracts/deployment-addresses/optimism.md
@@ -12,7 +12,7 @@ For more information on specific deployments as well as changelogs for different
 
 ### Routers
 
-<DeploymentAddresses chain="base" :active="true" group="routers" />
+<DeploymentAddresses chain="optimism" :active="true" group="routers" />
 
 ### Pool Factories
 


### PR DESCRIPTION
I realized today that links for Router's addresses were the base ones in optimism section.
