### PR TITLE
Add clarification about `onlyVault` modifier

### DIFF
--- a/docs/build/build-a-hook/extend-existing-pool-type.md
+++ b/docs/build/build-a-hook/extend-existing-pool-type.md
@@ -19,7 +19,7 @@ A hooks contract should inherit the [BaseHooks.sol](https://github.com/balancer/
 * **Base implementation**: A complete implementation of the [IHooks.sol](https://github.com/balancer/balancer-v3-monorepo/blob/main/pkg/interfaces/contracts/vault/IHooks.sol) interface, with each implemented function returning false.
 * **Configuration**: A virtual function `getHookFlags` that must be implemented by your hooks contract, defining which hooks your contract supports.
 
-Below, we present a naive implementation of a swap-fee discount hook contract giving any veBAL holder a reduced swap fee. Hooks should also inherit from `VaultGuard`, which stores a reference to the Vault and provides the `onlyVault` modifier. This is required for `onRegister` and hook overrides, to ensure they cannot be called except by the Vault.
+Below, we present a naive implementation of a swap-fee discount hook contract giving any veBAL holder a reduced swap fee. Hooks should also inherit from `VaultGuard`, which stores a reference to the Vault and provides the `onlyVault` modifier. **This is required for `onRegister` and hook overrides whenever they are capable of modifying the contract's state**, to ensure they cannot be called except by the Vault in the standard lifecycle of each particular operation. For hooks that are either `view` or `pure`, the modifier is not strictly necessary.
 
 ```solidity
 contract VeBALFeeDiscountHook is BaseHooks, VaultGuard {


### PR DESCRIPTION
`view` or `pure` functions don't strictly need `onlyVault` modifier, but functions that modify the contract's state must enforce it. Not doing so can be a costly mistake depending on what the hook does, so it's important to highlight this.