### PR TITLE
CLR Nested Pool support clarification

### DIFF
--- a/docs/build/build-a-router/existing-routers.md
+++ b/docs/build/build-a-router/existing-routers.md
@@ -118,7 +118,7 @@ Token arrays must always be in **token registration order** (the order the pool 
 | Initialize new pool | `Router` | `initialize` |
 | Multi-hop swaps | `BatchRouter` | `swapExactIn`, `swapExactOut` |
 | ERC4626 pool operations | `CompositeLiquidityRouter` | `addLiquidityUnbalancedToERC4626Pool` |
-| Nested pool operations | `CompositeLiquidityRouter` | `addLiquidityUnbalancedNestedPool` |
+| Nested pool operations | `CompositeLiquidityRouter` (V3+) | `addLiquidityUnbalancedNestedPool` |
 | Buffer management | `BufferRouter` | `initializeBuffer`, `addLiquidityToBuffer` |
 | Two-token unbalanced add | `UnbalancedAddViaSwapRouter` | `addLiquidityUnbalanced` |
 | LBP → Weighted Pool migration | `LBPMigrationRouter` | `migrateLiquidity` |

--- a/docs/concepts/router/overview.md
+++ b/docs/concepts/router/overview.md
@@ -37,7 +37,7 @@ Balancer has developed, audited and deployed Router contracts with the goal of p
 - [Code](https://github.com/balancer/balancer-v3-monorepo/blob/main/pkg/vault/contracts/BufferRouter.sol)
 
 ### Composite Liquidity Router
-- Liquidity operations on pools containing ERC4626 tokens, and nested pools (i.e. pools containing the BPT of other pools)
+- Liquidity operations on pools containing ERC4626 tokens, and nested pools (i.e. pools containing the BPT of other pools). Nested pools are supported in CLR V3.
 - [API](../../developer-reference/contracts/composite-liquidity-router-api.md)
 - [Code](https://github.com/balancer/balancer-v3-monorepo/blob/main/pkg/vault/contracts/CompositeLiquidityRouter.sol)
 

--- a/docs/concepts/router/queries.md
+++ b/docs/concepts/router/queries.md
@@ -46,8 +46,8 @@ The detailed Router API description can be found in the [Composite Liquidity Rou
 - `queryAddLiquidityUnbalancedToERC4626Pool`
 - `queryAddLiquidityProportionalToERC4626Pool`
 - `queryRemoveLiquidityProportionalFromERC4626Pool`
-- `queryAddLiquidityUnbalancedNestedPool`
-- `queryRemoveLiquidityProportionalNestedPool`
+- `queryAddLiquidityUnbalancedNestedPool` (V3+)
+- `queryRemoveLiquidityProportionalNestedPool` (V3+)
 
 ## Complex queries
 

--- a/docs/developer-reference/contracts/composite-liquidity-router-api.md
+++ b/docs/developer-reference/contracts/composite-liquidity-router-api.md
@@ -126,6 +126,8 @@ Removes liquidity proportionally from an ERC4626 pool, receiving underlying or w
 
 Nested pools contain BPTs from other pools as tokens. This router handles the complexity of traversing multiple pool levels.
 
+> NB: These nested pool functions will be introduced in CompositeLiquidityRouter V3, which is not yet released (as of January, 2026).
+
 **Important:** Pools with "overlapping" tokens (where both parent and child pools contain the same token) are not supported.
 
 #### `addLiquidityUnbalancedNestedPool`
@@ -309,6 +311,8 @@ Queries a `removeLiquidityProportionalFromERC4626Pool` operation without actuall
 | amountsOut | uint256[] memory | Expected amounts of tokens to receive |
 
 ### `queryAddLiquidityUnbalancedNestedPool`
+
+> NB: Nested pool operations will be introduced in CompositeLiquidityRouter V3, which is not yet released (as of January, 2026).
 
 ```solidity
 function queryAddLiquidityUnbalancedNestedPool(


### PR DESCRIPTION
Since we are not deploying V3 of the CLR for now (which supports nested operations), the current docs are a bit misleading. We'd already updated them to reflect V3, assuming it would be deployed, as it's been ready since last October.

Rather than remove the functions (and have to add them back in later when we eventually do release it), this PR just adds a note that nested operations are supported in V3, which has not yet been deployed.