### PR TITLE
Rename ReCLAMM to AutoRange

### DIFF
--- a/docs/concepts/core-concepts/bpt-oracles/bpt-oracles.md
+++ b/docs/concepts/core-concepts/bpt-oracles/bpt-oracles.md
@@ -81,7 +81,7 @@ Given these constraints, the key is to find k̃. To understand how, we start wit
 f(x₁, x₂, ..., xₙ) = D
 ```
 
-This is some function which, operating on the real balances, produces a single invariant value D, representing the total value of the pool. The details vary, but the Balancer Vault requires this to be defined for every pool type. So far, we have implemented oracles for both Weighted and Stable Balancer pools. (ReCLAMM pools should also work, as they are fundamentally Weighted pools, just incorporating virtual balances. See the ReClamm Pools section below.)
+This is some function which, operating on the real balances, produces a single invariant value D, representing the total value of the pool. The details vary, but the Balancer Vault requires this to be defined for every pool type. So far, we have implemented oracles for both Weighted and Stable Balancer pools. (AutoRange Pools should also work, as they are fundamentally Weighted pools, just incorporating virtual balances. See the AutoRange Pools section below.)
 
 The partial derivative ∂f/∂xⱼ represents how much the invariant changes per unit of token j, and the ratio of these partial derivatives represents the internal spot price of one token in terms of another. For instance, ∂f/∂x₂ / ∂f/∂x₁ would be the spot price of token 2 in terms of token 1.
 
@@ -178,11 +178,11 @@ C = k × Π((Pᵢ/Wᵢ)^Wᵢ) = TVL = Total pool value
 
 The price is then simply TVL / totalSupply.
 
-### ReCLAMM Pools
+### AutoRange Pools
 
-The same principle can be applied to a ReCLAMM pool, which is in practice a 50/50 weighted pool with virtual balances that concentrate the liquidity in a specified price range.
+The same principle can be applied to an AutoRange Pool, which is in practice a 50/50 weighted pool with virtual balances that concentrate the liquidity in a specified price range.
 
-The ReCLAMM invariant is
+The AutoRange Pool invariant is
 
 ```
 D = (Ra + Va)(Rb + Vb)

--- a/docs/concepts/core-concepts/concentrated-liquidity.md
+++ b/docs/concepts/core-concepts/concentrated-liquidity.md
@@ -66,18 +66,18 @@ When using with yield-bearing assets and rate providers, the precision can be in
 
 ![Non-fungible CL illustration](/images/rehype.png)
 
-### Readjusting Concentrated Liquidity AMM (ReClamm) Pools
+### AutoRange Pools
 
-[Reclamm Pools](../explore-available-balancer-pools/reclamm-pool/reclamm-pool.md) are the next logical step. To summarize the discussion above:
+[AutoRange Pools](../explore-available-balancer-pools/reclamm-pool/reclamm-pool.md) are the next logical step. To summarize the discussion above:
 
 Uniswap pools offer highly granular concentrated liquidity positions, but they are non-fungible and must be actively managed by the LP. There is a direct trade-off between capital efficiency and ease of management.
 
 Gyro pools offer fungible concentrated liquidity over moderate ranges, but the parameters are fixed, so management of volatile assets may involve liquidity migration.
 
-ReClamm pools offer fungible concentrated liquidity similar to 2-CLPs - but as the name implies, the parameters are not fixed. Essentially, the pools manage the liquidity on behalf of the LPs, with no user intervention required.
+AutoRange Pools offer fungible concentrated liquidity similar to 2-CLPs - but as the name implies, the parameters are not fixed. Essentially, the pools manage the liquidity on behalf of the LPs, with no user intervention required.
 
 Triggered by swaps or liquidity operations, the pool can adjust the price range automatically to keep itself “in range” (i.e., maintain the price within the liquidity bounds), whichever way the market moves. The pool creator can set the initial price range, as well as the margin - the “sensitivity” of the pool - which determines how quickly the pool responds to market price changes.
 
 Generally, the higher the volatility, the lower the margin, which makes the pool less sensitive to price changes and more gas-efficient. (If necessary, these can even be changed after deployment - but only slowly, to prevent manipulation.)
 
-The field is always advancing. There are now "ALMs" (automated liquidity managers), third party services that can relieve users of position maintenance. For instance, Arrakis Pro works on Uniswap V3 and V4, but has much broader application. The focused goal of ReClamm pools is to remove the burden of active user management, without sacrificing capital efficiency: a true "fire-and-forget" concentrated liquidity position native to Balancer. And in contrast to some "strategy" solutions, it is completely transparent.
+The field is always advancing. There are now "ALMs" (automated liquidity managers), third party services that can relieve users of position maintenance. For instance, Arrakis Pro works on Uniswap V3 and V4, but has much broader application. The focused goal of AutoRange Pools is to remove the burden of active user management, without sacrificing capital efficiency: a true "fire-and-forget" concentrated liquidity position native to Balancer. And in contrast to some "strategy" solutions, it is completely transparent.

--- a/docs/concepts/explore-available-balancer-pools/README.md
+++ b/docs/concepts/explore-available-balancer-pools/README.md
@@ -13,7 +13,7 @@ Let's explore some of the diverse pool types within the Balancer Protocol, each 
 - [Boosted Pool](./boosted-pool.md): Boosted Pools are designed to allow for greater capital efficiency, deeper liquidity, and increased yield for Liquidity Providers.
 - [Liquidity Bootstrapping Pools](./liquidity-bootstrapping-pool.md): Liquidity Bootstrapping Pools (LBPs) are pools that can dynamically change token weighting. LBPs create sell pressure and fair market advantages. Used very successfully for fair token launches.
 - [Gyroscope Pools](./gyroscope-pool/README.md): Fungible concentrated liquidity pools. Providing liquidity over a fixed price range gives liquidity providers better capital efficiency, and traders  better execution prices.
-- [reCLAMM Pools](./reclamm-pool/reclamm-pool.md): Concentrated liquidity pools with self-adjusting parameters. A "fire-and-forget" solution to maintenance-free concentrated liquidity provision.
+- [AutoRange Pools](./reclamm-pool/reclamm-pool.md): Fungible concentrated liquidity pools that automatically adjust the price range according to market conditions. A "fire-and-forget" solution to maintenance-free concentrated liquidity provision.
 
 Every pool type is associated with its own Factory contract, facilitating the creation of new pools. Experienced developers can find the factory deployment addresses through [this resource](../../developer-reference/contracts/deployment-addresses/mainnet.md). For further assistance, individuals are encouraged to contact our developers via [Discord](https://discord.balancer.fi/).
 

--- a/docs/concepts/explore-available-balancer-pools/liquidity-bootstrapping-pool/liquidity-bootstrapping-pool.md
+++ b/docs/concepts/explore-available-balancer-pools/liquidity-bootstrapping-pool/liquidity-bootstrapping-pool.md
@@ -74,7 +74,7 @@ The migration happens via the [`LBPMigrationRouter`](https://github.com/balancer
 
 ::: tip
 
-**Primary Use Case:** This feature is most commonly used for **Token Launches**, where the LBP concludes with a successful distribution and the project wishes to establish permanent liquidity. By migrating to a reCLAMM or Weighted pool, the project token becomes immediately tradable on Balancer.
+**Primary Use Case:** This feature is most commonly used for **Token Launches**, where the LBP concludes with a successful distribution and the project wishes to establish permanent liquidity. By migrating to an AutoRange or Weighted pool, the project token becomes immediately tradable on Balancer.
 
 :::
 

--- a/docs/concepts/explore-available-balancer-pools/reclamm-pool/reclamm-pool-math.md
+++ b/docs/concepts/explore-available-balancer-pools/reclamm-pool/reclamm-pool-math.md
@@ -1,15 +1,15 @@
 ---
 order: 7
-title: reCLAMM Pool Math
+title: AutoRange Pool Math
 ---
 
-# Readjusting Concentrated Liquidity AMM Pool Math
+# AutoRange Pool Math
 
 ## Intro
 
-The `Readjusting Concentrated Liquidity AMM` (reCLAMM) is a pool based on a "constant product," essentially equivalent to standard weighted math (with a clever redefinition of the token balances). The idea is to concentrate liquidity by adding price bounds to the constant product curve using virtual balances: $L = (R_a + V_a)(R_b + V_b)$, where $R_a$ and $R_b$ are the real balances of the token, and $V_a$ and $V_b$ are the virtual balances of the token.
+The AutoRange Pool is based on a "constant product," essentially equivalent to standard weighted math (with a clever redefinition of the token balances). The idea is to concentrate liquidity by adding price bounds to the constant product curve using virtual balances: $L = (R_a + V_a)(R_b + V_b)$, where $R_a$ and $R_b$ are the real balances of the token, and $V_a$ and $V_b$ are the virtual balances of the token.
 
-Currently, in fungible concentrated liquidity pools with fixed price intervals, LPs may need to actively migrate liquidity between CL pools to avoid losing fee revenue to pools that have gone out of range. The `Readjusting CL AMM` is a pool that automatically readjusts the price interval, so that a retail LP can confidently deposit assets and rely on the pool to manage them efficiently and profitably.
+Currently, in fungible concentrated liquidity pools with fixed price intervals, LPs may need to actively migrate liquidity between CL pools to avoid losing fee revenue to pools that have gone out of range. The AutoRange Pool automatically readjusts the price interval, so that a retail LP can confidently deposit assets and rely on the pool to manage them efficiently and profitably.
 
 ## Concepts
 
@@ -19,13 +19,13 @@ Virtual Balances can be understood as offsets to the real token balances, so tha
 
 Therefore, even if the real balance of a token goes to zero, the virtual balance will keep the token balance (and therefore price) above zero. In practice, it restricts the token price between two bounds, defined by the virtual balances of each token. The image below illustrates a constant product price curve with hard price limits, "soft" margins (described later - basically the threshold where the pool will begin self-adjusting), and the "target" price, usually close to the middle of the range.
 
-![reCLAMM price curve illustration](/images/reclamm-initial-state.png)
+![AutoRange price curve illustration](/images/reclamm-initial-state.png)
 
 ### Initial Virtual Balances
 
 During pool creation, the pool creator will define the `minimum price` ($P_{a_{min}}$) and the `maximum price` ($P_{a_{max}}$). Given these three parameters, we can calculate the initial virtual balances.
 
-The invariant of a reCLAMM Pool is calculated as follows:
+The invariant of an AutoRange Pool is calculated as follows:
 
 $L = (R_a + V_a)(R_b + V_b)$
 
@@ -105,7 +105,7 @@ The Price Ratio is the ratio between the high and low price bounds of the range.
 
 The highest price of A ($P_{max_A}$) is reached when the real balance of A is 0. So, the price is defined as:
 
-![reCLAMM price equation](/images/reclamm-price-equation.png)
+![AutoRange price equation](/images/reclamm-price-equation.png)
 
 The Price Ratio is calculated as $Q_0^2 = \frac{P_{max_A}}{P_{min_A}}$.
 

--- a/docs/concepts/explore-available-balancer-pools/reclamm-pool/reclamm-pool.md
+++ b/docs/concepts/explore-available-balancer-pools/reclamm-pool/reclamm-pool.md
@@ -1,16 +1,16 @@
 ---
 order: 6
-title: Readjusting Concentrated Liquidity AMM Pool
+title: AutoRange Pool
 ---
 
-# Readjusting Concentrated Liquidity AMM Pools
+# AutoRange Pools
 
 ## Overview
 
-reCLAMM Pools are a type of **concentrated liquidity pool** that focus liquidity within a predefined price range, allowing LPs to earn greater fees with less capital—especially when the market price remains within that range. This concentration is initialized with a **target price** and **range bounds**, enabling the pool to deliver capital efficiency over traditional constant-product models.
+AutoRange Pools are **fungible concentrated liquidity pools** that focus liquidity within a predefined price range, allowing LPs to earn greater fees with less capital—especially when the market price remains within that range. This concentration is initialized with a **target price** and **range bounds**, enabling the pool to deliver capital efficiency over traditional constant-product models.
 
-What sets reCLAMM apart is its **adaptive nature**. As trading activity or liquidity operations shift the market price, reCLAMM Pools are able to **automatically move** their price range—up or down the price curve—without any intervention from users or governance. This "re-centering" behavior activates only when the pool becomes sufficiently unbalanced, based on a margin threshold defined at deployment. Once triggered, the pool begins gradually shifting its range in the direction of market pressure, ensuring liquidity stays useful and active.
-To enable this adaptive behavior, reCLAMM Pools are configured with a few key parameters:
+What sets AutoRange Pools apart is their **adaptive nature**. As trading activity or liquidity operations shift the market price, AutoRange Pools are able to **automatically move** their price range—up or down the price curve—without any intervention from users or governance. This "re-centering" behavior activates only when the pool becomes sufficiently unbalanced, based on a margin threshold defined at deployment. Once triggered, the pool begins gradually shifting its range in the direction of market pressure, ensuring liquidity stays useful and active.
+To enable this adaptive behavior, AutoRange Pools are configured with a few key parameters:
 
 - A **target price**, often set near the current market price at deployment.
 - A **price range**, where all the pool’s liquidity is initially concentrated.
@@ -21,14 +21,14 @@ For example, if the margin is set at 20%, the pool tolerates up to a 60/40 imbal
 
 This design offers LPs the benefit of concentrated liquidity **without the need for manual range resets**. It suits passive LPs seeking to stay aligned with market trends while still capturing the fee benefits of a tighter range.
 
-Those familiar with other concentrated liquidity designs may notice echoes of similar mechanisms—like pools that start with fixed ranges around a target price—but unlike those, reCLAMM’s range is not locked. Instead, it evolves in response to the market, maintaining efficiency over time without additional user action.
+Those familiar with other concentrated liquidity designs may notice echoes of similar mechanisms—like pools that start with fixed ranges around a target price—but unlike those, an AutoRange Pool's range is not locked. Instead, it evolves in response to the market, maintaining efficiency over time without additional user action.
 
 The following diagram shows a pool that is `OUT OF RANGE`. The current price is within the price range (as it must be), but above the margin. In this state, the pool will be shifting the price range "up" toward higher prices, following the market, and attempting to bring the market price back inside the margins.
 
-![reCLAMM out of range](/images/PoolRange.png)
+![AutoRange pool out of range](/images/PoolRange.png)
 
 ::: info
-reCLAMM Pools are always two-token pools.
+AutoRange Pools are always two-token pools.
 
 - The minimum swap fee percentage is 0.001% (note - same as the Weighted Pool)
 - The maximum swap fee is 10%
@@ -40,15 +40,15 @@ Note that the swap fee and invariant limits are defined in `ReClammPool` through
 
 See [here](../../../integration-guides/aggregators/pool-maths-and-details.md) for a more detailed reference.
 
-## Advantages of reCLAMM Pools
+## Advantages of AutoRange Pools
 
 - All the benefits of concentrated liquidity: higher fees and better capital efficiency (when in range, same math as UniV3)
 - None of the maintenance required with traditional concentrated liquidity pools: LP-and-forget
-- Moreover, unlike third party ALMs, the rebalancing is entirely transparent
+- Moreover, unlike with third-party ALMs, the price range adjustment is entirely transparent
 - Fungible positions can be incentivized, making them ideal for guaranteeing deep DAO token liquidity
 - Calculations simplified by having all LPs share the same price range
-- reCLAMM Pools automatically adjust to market conditions; LPs should always be earning fees
-- While designed to be maintenance-free, reCLAMM Pools are tunable by admins if necessary in extreme conditions
+- AutoRange Pools automatically adjust to market conditions; LPs should always be earning fees
+- While designed to be maintenance-free, AutoRange Pools are tunable by admins if necessary in extreme conditions
 
 These are designed for maintaining deep liquidity, and should not be used for token launches, or with tokens that have low liquidity or otherwise manipulable prices (e.g., using direct collateral or relying on non-aggregated on-chain oracles).
 
@@ -90,13 +90,13 @@ Finally, we validate that the ratio of the real balances corresponds to the theo
 
 We provide a helper function, `computeInitialBalancesRaw`, to assist with these calculations. Given the actual intended deposit amount of one of the tokens - and the initial parameters set on deployment - the contract can calculate how much of the other token must be supplied to pass all the initialization checks.
 
-One final twist involves the handling of wrapped tokens with rate providers, which are expected to be commonly used in reCLAMM Pools. Recall that the prices are passed in during initialization - but how were they calculated? It's possible the pool creator wants to use the direct price of the wrapped token (e.g., for non-boosted pools with tokens like wstETH). In this case, the price does not include the rate provider, even though the token has one. In other cases (e.g., boosted pools with tokens like waUSDC), the creator might want to use the price of the underlying token instead. In that case, the price does incorporate the rate, and the initialization calculation must accommodate that. Accordingly, along with the price range and target values, the pool is deployed with flags indicating whether to use the rate provider for each token during initialization.
+One final twist involves the handling of wrapped tokens with rate providers, which are expected to be commonly used in AutoRange Pools. Recall that the prices are passed in during initialization - but how were they calculated? It's possible the pool creator wants to use the direct price of the wrapped token (e.g., for non-boosted pools with tokens like wstETH). In this case, the price does not include the rate provider, even though the token has one. In other cases (e.g., boosted pools with tokens like waUSDC), the creator might want to use the price of the underlying token instead. In that case, the price does incorporate the rate, and the initialization calculation must accommodate that. Accordingly, along with the price range and target values, the pool is deployed with flags indicating whether to use the rate provider for each token during initialization.
 
 ## Centeredness Margin
 
 The centeredness margin is another parameter that must be set on deployment. Unlike the initial target and range, it is not immutable, and can be changed later by admin action.
 
-This is a percentage value in the range of 0 - 90%. A value of 0 would mean there is effectively no margin - real balances can go to 0, and the pool will never readjust. This degenerate case is effectively the same as a Gyro 2-CLP at the full price range: completely insensitive to price movement, until the pool goes out of range and effectively halts. (Technically, reCLAMM pools act like 2-CLPs constructed with the current range whenever they're in range and not updating the price ratio.)
+This is a percentage value in the range of 0 - 90%. A value of 0 would mean there is effectively no margin - real balances can go to 0, and the pool will never readjust. This degenerate case is effectively the same as a Gyro 2-CLP at the full price range: completely insensitive to price movement, until the pool goes out of range and effectively halts. (Technically, AutoRange Pools act like 2-CLPs constructed with the current range whenever they're in range and not updating the price ratio.)
 
 A value of 100% would mean the pool is always "out of range," unless it is _perfectly_ balanced. This is maximal sensitivity to price changes; essentially it would always be shifting the range (and incurring somewhat higher gas costs). Since the margin can only be changed when the pool is in range both before and after, it would be very difficult to lower it from 100%. Mainly for this reason, the maximum was set to 90%. We expect most pools to be configured somewhere in the middle.
 
@@ -110,7 +110,7 @@ When the centeredness falls below 50%, the market price point will be above the 
 
 ## Daily price shift exponent
 
-The centeredness margin is the final parameter (relating to reCLAMM functionality) that must be set on deployment. Unlike the initial target and range, it is not immutable, and can be changed later by admin action.
+The daily price shift exponent is the final parameter (specific to AutoRange Pools) that must be set on deployment. Unlike the initial target and range, it is not immutable, and can be changed later by admin action.
 
 This is also a percentage, and it controls the "doubling rate" of the price shift. At 100%, the prices will double (or halve) in one day. This rate is non-linear, and means that the prices will be multiplied (or divided) by 2^(`dailyPriceShiftExponent`) per day. So 200% corresponds to 2^2 or 4x, and 300% corresponds to 2^3 or 8x. (The maximum is 100%, or doubling once per day.)
 
@@ -118,7 +118,7 @@ Note that the math prevents the price from "overshooting" in either direction du
 
 ## Admin actions
 
-reCLAMM Pool admins can do three things: 1) change the centeredness margin (the threshold for updates); 2) change the daily price shift exponent (the speed of updates); and 3) initiate an update to the price interval (i.e., the distance, or ratio, between the minimum and maximum price bounds), or simply stop an ongoing update. All of these changes will update the virtual balances (and potentially slightly change the price).
+AutoRange Pool admins can do three things: 1) change the centeredness margin (the threshold for updates); 2) change the daily price shift exponent (the speed of updates); and 3) initiate an update to the price interval (i.e., the distance, or ratio, between the minimum and maximum price bounds), or simply stop an ongoing update. All of these changes will update the virtual balances (and potentially slightly change the price).
 
 All of these functions require the pool to be initialized.
 
@@ -134,6 +134,6 @@ Note that it is possible for the price range to be both shifting up or down and 
 
 ## Simulator
 
-A simulator is deployed [here](https://aclamm.web.app/reclamm). You can set the initial parameters manually - or load them from a real deployed reCLAMM pool, then change the settings to see how a real pool would respond (including simulating swaps).
+A simulator is deployed [here](https://aclamm.web.app/reclamm). You can set the initial parameters manually - or load them from a real deployed AutoRange Pool, then change the settings to see how a real pool would respond (including simulating swaps).
 
 See [this page](./reclamm-pool-math.md) for details of the math.

--- a/docs/concepts/router/overview.md
+++ b/docs/concepts/router/overview.md
@@ -42,7 +42,7 @@ Balancer has developed, audited and deployed Router contracts with the goal of p
 - [Code](https://github.com/balancer/balancer-v3-monorepo/blob/main/pkg/vault/contracts/CompositeLiquidityRouter.sol)
 
 ### Add Unbalanced Via Swap Router
-- Specialized router for adding unbalanced liquidity to two-token pools by combining a proportional add with a swap. Useful for pool types that don't natively allow unbalanced liquidity (e.g., ReCLAMMs).
+- Specialized router for adding unbalanced liquidity to two-token pools by combining a proportional add with a swap. Useful for pool types that don't natively allow unbalanced liquidity (e.g., AutoRange Pools).
 - [API](../../developer-reference/contracts/unbalanced-add-via-swap-router-api.md)
 - [Code](https://github.com/balancer/balancer-v3-monorepo/blob/main/pkg/vault/contracts/UnbalancedAddViaSwapRouter.sol)
 

--- a/docs/developer-reference/repositories.md
+++ b/docs/developer-reference/repositories.md
@@ -119,7 +119,7 @@ Mathematical libraries and implementations for Balancer V3 pool calculations, in
 #### [ReCLAMM](https://github.com/balancer/reclamm)
 **Status:** Actively maintained (December 2024) • 3 stars • 4 forks
 
-Readjusting Concentrated Liquidity AMM (ReCLAMM) implementation for Balancer V3, providing advanced concentrated liquidity features.
+AutoRange Pools implementation for Balancer V3 — fungible concentrated liquidity pools that automatically adjust the price range according to market conditions.
 
 **Repository:** https://github.com/balancer/reclamm  
 **Primary Use:** Advanced concentrated liquidity features

--- a/docs/integration-guides/aggregators/pool-maths-and-details.md
+++ b/docs/integration-guides/aggregators/pool-maths-and-details.md
@@ -290,12 +290,12 @@ query MyQuery {
 }
 ```
 
-## reCLAMM Pools
+## AutoRange Pools
 
-reCLAMM Pools are two-token concentrated liquidity pools conceptually similar to 2-CLPs, but the parameters are not immutable. They can be changed not only by admins, but also by the pool itself, as it automatically adjusts virtual balances to shift the price range as necessary to keep the pool balanced (and earning fees for LPs).
+AutoRange Pools are two-token fungible concentrated liquidity pools conceptually similar to 2-CLPs, but the parameters are not immutable. They can be changed not only by admins, but also by the pool itself, as it automatically adjusts virtual balances to shift the price range as necessary to keep the pool balanced (and earning fees for LPs).
 
 ::: warning V2 Changes
-V1 reCLAMM pools are deprecated in favour of V2. 
+V1 AutoRange Pools are deprecated in favour of V2. 
 V2 has a small maths fix to handle an edge case when pool is out of range.
 They have independent factories. If using the API please use `version` to differentiate. 
 :::


### PR DESCRIPTION
Change the marketing name to the new one. Have to look at what else needs to change here (e.g., the simulator?)