### PR TITLE
Fix veBAL Etherscan contract link on FAQ page

### DIFF
--- a/docs/concepts/governance/veBAL/FAQ.md
+++ b/docs/concepts/governance/veBAL/FAQ.md
@@ -85,7 +85,7 @@ The veBAL and gauge contracts remain deployed on-chain (locks persist until natu
 
 | Contract                                                                                                        | Purpose                                              |
 |:----------------------------------------------------------------------------------------------------------------|:-----------------------------------------------------|
-| [veBAL](https://etherscan.io/tx/0xaa29cd251cdb024c415b0e13f67a0ca74fe5abc3de9a9fedd1ae26fd39be4025)             | Locked BPTs and reported veBAL balances              |
+| [veBAL](https://etherscan.io/address/0xC128a9954e6c874eA3d62ce62B468bA073093F25)                               | Locked BPTs and reported veBAL balances              |
 | [Gauge Controller](https://etherscan.io/address/0xC128468b7Ce63eA702C1f104D55A2566b13D3ABD)                     | Managed gauges and emissions                         |
 | [Gauge Adder](https://etherscan.io/address/0x2fFB7B215Ae7F088eC2530C7aa8E1B24E398f26a)                          | Added new gauges approved by governance              |
 | [Mainnet Uncapped Gauge Factory](https://etherscan.io/address/0x4e7bbd911cf1efa442bc1b2e9ea01ffe785412ec)       | Create gauges with no cap on Mainnet                 |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- The veBAL FAQ contract table linked the veBAL contract to an Etherscan **transaction** URL (`/tx/...`) instead of the contract address.
- Updated the link to `https://etherscan.io/address/0xC128a9954e6c874eA3d62ce62B468bA073093F25` (VotingEscrow / veBAL), matching the address already documented on the Voting page.

## Test plan
- [ ] Open the veBAL FAQ page and confirm the veBAL row links to the contract address page on Etherscan
- [ ] Confirm the linked address matches `0xC128a9954e6c874eA3d62ce62B468bA073093F25`
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://balancerecosystem.slack.com/archives/C02C3NW4FDZ/p1786024454775929?thread_ts=1786024454.775929&cid=C02C3NW4FDZ)

<div><a href="https://cursor.com/agents/bc-6d921cbd-d473-5ded-ab72-7cf4fd0f0d99?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6d921cbd-d473-5ded-ab72-7cf4fd0f0d99&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

